### PR TITLE
Fix: Soluciona SqlNullValueException y revierte a SQL Server

### DIFF
--- a/src/DataAccess/ApplicationDbContext.cs
+++ b/src/DataAccess/ApplicationDbContext.cs
@@ -212,14 +212,12 @@ namespace DataAccess
             });
         }
 
-        private static readonly Microsoft.Data.Sqlite.SqliteConnection _connection = new Microsoft.Data.Sqlite.SqliteConnection("DataSource=:memory:");
-
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!optionsBuilder.IsConfigured)
             {
-                _connection.Open();
-                optionsBuilder.UseSqlite(_connection);
+                // Usa la cadena de conexión de tu appsettings.json o ponla aquí directamente para pruebas
+                optionsBuilder.UseSqlServer("Server=localhost;Database=login2;Trusted_Connection=True;TrustServerCertificate=True;");
             }
         }
 

--- a/src/DataAccess/DataAccess.csproj
+++ b/src/DataAccess/DataAccess.csproj
@@ -13,7 +13,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/DataAccess/Migrations/20250717025522_AllowNullsInUsuarioForSqlServer.Designer.cs
+++ b/src/DataAccess/Migrations/20250717025522_AllowNullsInUsuarioForSqlServer.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -11,34 +12,40 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAccess.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250717024945_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20250717025522_AllowNullsInUsuarioForSqlServer")]
+    partial class AllowNullsInUsuarioForSqlServer
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.7");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "9.0.7")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("DataAccess.Entities.Contacto", b =>
                 {
                     b.Property<int>("IdContacto")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_contacto");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdContacto"));
 
                     b.Property<string>("Celular")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasColumnName("celular");
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasColumnName("email");
 
                     b.Property<int>("IdPersona")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_persona");
 
                     b.HasKey("IdContacto");
@@ -52,13 +59,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdGenero")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_genero");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdGenero"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(25)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(25)")
                         .HasColumnName("genero");
 
                     b.HasKey("IdGenero");
@@ -70,16 +79,18 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdHistorial")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdHistorial"));
 
                     b.Property<byte[]>("ContrasenaScript")
                         .IsRequired()
-                        .HasColumnType("BLOB")
+                        .HasColumnType("varbinary(max)")
                         .HasColumnName("contrasena_script");
 
                     b.Property<int>("IdUsuario")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
                     b.HasKey("IdHistorial");
@@ -91,17 +102,19 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdLocalidad")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_localidad");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdLocalidad"));
+
                     b.Property<int>("IdPartido")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_partido");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("localidad");
 
                     b.HasKey("IdLocalidad");
@@ -115,17 +128,19 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPartido")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_partido");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPartido"));
+
                     b.Property<int>("IdProvincia")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_provincia");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("partido");
 
                     b.HasKey("IdPartido");
@@ -139,19 +154,21 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPermiso")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_permiso");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPermiso"));
 
                     b.Property<string>("Descripcion")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(200)")
                         .HasColumnName("descripcion");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("permiso");
 
                     b.HasKey("IdPermiso");
@@ -162,15 +179,15 @@ namespace DataAccess.Migrations
             modelBuilder.Entity("DataAccess.Entities.PermisoUsuario", b =>
                 {
                     b.Property<int>("IdUsuario")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
                     b.Property<int>("IdPermiso")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_permiso");
 
                     b.Property<DateTime>("FechaVencimiento")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("fecha_vencimiento");
 
                     b.HasKey("IdUsuario", "IdPermiso");
@@ -182,68 +199,70 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPersona")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_persona");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPersona"));
 
                     b.Property<string>("Altura")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("altura");
 
                     b.Property<string>("Apellido")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("apellido");
 
                     b.Property<string>("Calle")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("calle");
 
                     b.Property<string>("Correo")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(100)")
                         .HasColumnName("correo");
 
                     b.Property<string>("Cuil")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(10)")
                         .HasColumnName("cuil");
 
                     b.Property<DateTime>("FechaIngreso")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("IdGenero")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_genero");
 
                     b.Property<int>("IdLocalidad")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_localidad");
 
                     b.Property<int>("IdTipoDoc")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_tipo_doc");
 
                     b.Property<int>("Legajo")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("legajo");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("nombre");
 
                     b.Property<string>("NumDoc")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(20)")
                         .HasColumnName("num_doc");
 
                     b.HasKey("IdPersona");
@@ -261,39 +280,41 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPolitica")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_politica");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPolitica"));
+
                     b.Property<bool>("Autenticacion2FA")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("autenticacion_2fa");
 
                     b.Property<int>("CantPreguntas")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("cant_preguntas");
 
                     b.Property<bool>("CaracterEspecial")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("caracter_especial");
 
                     b.Property<bool>("LetrasYNumeros")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("letras_y_numeros");
 
                     b.Property<bool>("MayusYMinus")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("mayus_y_minus");
 
                     b.Property<int>("MinCaracteres")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("min_caracteres");
 
                     b.Property<bool>("NoRepetirAnteriores")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("no_repetir_anteriores");
 
                     b.Property<bool>("SinDatosPersonales")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("sin_datos_personales");
 
                     b.HasKey("IdPolitica");
@@ -305,13 +326,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPregunta")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_pregunta");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPregunta"));
 
                     b.Property<string>("Pregunta")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(255)")
                         .HasColumnName("pregunta");
 
                     b.HasKey("IdPregunta");
@@ -323,13 +346,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdProvincia")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_provincia");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdProvincia"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("provincia");
 
                     b.HasKey("IdProvincia");
@@ -340,16 +365,16 @@ namespace DataAccess.Migrations
             modelBuilder.Entity("DataAccess.Entities.RespuestaSeguridad", b =>
                 {
                     b.Property<int>("IdUsuario")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
                     b.Property<int>("IdPregunta")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_pregunta");
 
                     b.Property<string>("Respuesta")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasColumnName("respuesta");
 
                     b.HasKey("IdUsuario", "IdPregunta");
@@ -361,13 +386,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdRol")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_rol");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdRol"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("rol");
 
                     b.HasKey("IdRol");
@@ -378,11 +405,11 @@ namespace DataAccess.Migrations
             modelBuilder.Entity("DataAccess.Entities.RolPermiso", b =>
                 {
                     b.Property<int>("IdRol")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_rol");
 
                     b.Property<int>("IdPermiso")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_permiso");
 
                     b.HasKey("IdRol", "IdPermiso");
@@ -396,13 +423,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdTipoDoc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_tipo_doc");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdTipoDoc"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("tipo_doc");
 
                     b.HasKey("IdTipoDoc");
@@ -414,43 +443,45 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdUsuario")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdUsuario"));
+
                     b.Property<bool>("CambioContrasenaObligatorio")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("CambioContrasenaObligatorio");
 
                     b.Property<byte[]>("ContrasenaScript")
                         .IsRequired()
-                        .HasColumnType("BLOB")
+                        .HasColumnType("varbinary(max)")
                         .HasColumnName("contrasena_script");
 
                     b.Property<DateTime?>("FechaBloqueo")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("fecha_bloqueo");
 
                     b.Property<DateTime>("FechaUltimoCambio")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("fecha_ultimo_cambio");
 
                     b.Property<int>("IdPersona")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_persona");
 
                     b.Property<int>("IdRol")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_rol");
 
                     b.Property<string>("NombreUsuarioBloqueo")
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("nombre_usuario_bloqueo");
 
                     b.Property<string>("UsuarioNombre")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("usuario");
 
                     b.HasKey("IdUsuario");

--- a/src/DataAccess/Migrations/20250717025522_AllowNullsInUsuarioForSqlServer.cs
+++ b/src/DataAccess/Migrations/20250717025522_AllowNullsInUsuarioForSqlServer.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace DataAccess.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialCreate : Migration
+    public partial class AllowNullsInUsuarioForSqlServer : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -15,9 +15,9 @@ namespace DataAccess.Migrations
                 name: "generos",
                 columns: table => new
                 {
-                    id_genero = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    genero = table.Column<string>(type: "TEXT", maxLength: 25, nullable: false)
+                    id_genero = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    genero = table.Column<string>(type: "nvarchar(25)", maxLength: 25, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -28,10 +28,10 @@ namespace DataAccess.Migrations
                 name: "historial_contrasena",
                 columns: table => new
                 {
-                    id = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    id_usuario = table.Column<int>(type: "INTEGER", nullable: false),
-                    contrasena_script = table.Column<byte[]>(type: "BLOB", nullable: false)
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    id_usuario = table.Column<int>(type: "int", nullable: false),
+                    contrasena_script = table.Column<byte[]>(type: "varbinary(max)", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -42,10 +42,10 @@ namespace DataAccess.Migrations
                 name: "permisos",
                 columns: table => new
                 {
-                    id_permiso = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    permiso = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
-                    descripcion = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false)
+                    id_permiso = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    permiso = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    descripcion = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -56,9 +56,9 @@ namespace DataAccess.Migrations
                 name: "permisos_usuarios",
                 columns: table => new
                 {
-                    id_usuario = table.Column<int>(type: "INTEGER", nullable: false),
-                    id_permiso = table.Column<int>(type: "INTEGER", nullable: false),
-                    fecha_vencimiento = table.Column<DateTime>(type: "TEXT", nullable: false)
+                    id_usuario = table.Column<int>(type: "int", nullable: false),
+                    id_permiso = table.Column<int>(type: "int", nullable: false),
+                    fecha_vencimiento = table.Column<DateTime>(type: "datetime2", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -69,16 +69,16 @@ namespace DataAccess.Migrations
                 name: "politicas_seguridad",
                 columns: table => new
                 {
-                    id_politica = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    min_caracteres = table.Column<int>(type: "INTEGER", nullable: false),
-                    cant_preguntas = table.Column<int>(type: "INTEGER", nullable: false),
-                    mayus_y_minus = table.Column<bool>(type: "INTEGER", nullable: false),
-                    letras_y_numeros = table.Column<bool>(type: "INTEGER", nullable: false),
-                    caracter_especial = table.Column<bool>(type: "INTEGER", nullable: false),
-                    autenticacion_2fa = table.Column<bool>(type: "INTEGER", nullable: false),
-                    no_repetir_anteriores = table.Column<bool>(type: "INTEGER", nullable: false),
-                    sin_datos_personales = table.Column<bool>(type: "INTEGER", nullable: false)
+                    id_politica = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    min_caracteres = table.Column<int>(type: "int", nullable: false),
+                    cant_preguntas = table.Column<int>(type: "int", nullable: false),
+                    mayus_y_minus = table.Column<bool>(type: "bit", nullable: false),
+                    letras_y_numeros = table.Column<bool>(type: "bit", nullable: false),
+                    caracter_especial = table.Column<bool>(type: "bit", nullable: false),
+                    autenticacion_2fa = table.Column<bool>(type: "bit", nullable: false),
+                    no_repetir_anteriores = table.Column<bool>(type: "bit", nullable: false),
+                    sin_datos_personales = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -89,9 +89,9 @@ namespace DataAccess.Migrations
                 name: "preguntas_seguridad",
                 columns: table => new
                 {
-                    id_pregunta = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    pregunta = table.Column<string>(type: "TEXT", maxLength: 255, nullable: false)
+                    id_pregunta = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    pregunta = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -102,9 +102,9 @@ namespace DataAccess.Migrations
                 name: "provincias",
                 columns: table => new
                 {
-                    id_provincia = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    provincia = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false)
+                    id_provincia = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    provincia = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -115,9 +115,9 @@ namespace DataAccess.Migrations
                 name: "respuestas_seguridad",
                 columns: table => new
                 {
-                    id_usuario = table.Column<int>(type: "INTEGER", nullable: false),
-                    id_pregunta = table.Column<int>(type: "INTEGER", nullable: false),
-                    respuesta = table.Column<string>(type: "TEXT", nullable: false)
+                    id_usuario = table.Column<int>(type: "int", nullable: false),
+                    id_pregunta = table.Column<int>(type: "int", nullable: false),
+                    respuesta = table.Column<string>(type: "nvarchar(max)", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -128,9 +128,9 @@ namespace DataAccess.Migrations
                 name: "roles",
                 columns: table => new
                 {
-                    id_rol = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    rol = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false)
+                    id_rol = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    rol = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -141,9 +141,9 @@ namespace DataAccess.Migrations
                 name: "tipo_doc",
                 columns: table => new
                 {
-                    id_tipo_doc = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    tipo_doc = table.Column<string>(type: "TEXT", maxLength: 30, nullable: false)
+                    id_tipo_doc = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    tipo_doc = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -154,10 +154,10 @@ namespace DataAccess.Migrations
                 name: "partidos",
                 columns: table => new
                 {
-                    id_partido = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    partido = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
-                    id_provincia = table.Column<int>(type: "INTEGER", nullable: false)
+                    id_partido = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    partido = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    id_provincia = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -174,8 +174,8 @@ namespace DataAccess.Migrations
                 name: "rol_permiso",
                 columns: table => new
                 {
-                    id_rol = table.Column<int>(type: "INTEGER", nullable: false),
-                    id_permiso = table.Column<int>(type: "INTEGER", nullable: false)
+                    id_rol = table.Column<int>(type: "int", nullable: false),
+                    id_permiso = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -198,16 +198,16 @@ namespace DataAccess.Migrations
                 name: "usuarios",
                 columns: table => new
                 {
-                    id_usuario = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    usuario = table.Column<string>(type: "TEXT", maxLength: 30, nullable: false),
-                    contrasena_script = table.Column<byte[]>(type: "BLOB", nullable: false),
-                    id_persona = table.Column<int>(type: "INTEGER", nullable: false),
-                    fecha_bloqueo = table.Column<DateTime>(type: "TEXT", nullable: true),
-                    nombre_usuario_bloqueo = table.Column<string>(type: "TEXT", maxLength: 30, nullable: true),
-                    fecha_ultimo_cambio = table.Column<DateTime>(type: "TEXT", nullable: false),
-                    id_rol = table.Column<int>(type: "INTEGER", nullable: false),
-                    CambioContrasenaObligatorio = table.Column<bool>(type: "INTEGER", nullable: false)
+                    id_usuario = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    usuario = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    contrasena_script = table.Column<byte[]>(type: "varbinary(max)", nullable: false),
+                    id_persona = table.Column<int>(type: "int", nullable: false),
+                    fecha_bloqueo = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    nombre_usuario_bloqueo = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: true),
+                    fecha_ultimo_cambio = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    id_rol = table.Column<int>(type: "int", nullable: false),
+                    CambioContrasenaObligatorio = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -224,10 +224,10 @@ namespace DataAccess.Migrations
                 name: "localidades",
                 columns: table => new
                 {
-                    id_localidad = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    localidad = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
-                    id_partido = table.Column<int>(type: "INTEGER", nullable: false)
+                    id_localidad = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    localidad = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    id_partido = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -244,20 +244,20 @@ namespace DataAccess.Migrations
                 name: "personas",
                 columns: table => new
                 {
-                    id_persona = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    legajo = table.Column<int>(type: "INTEGER", nullable: false),
-                    nombre = table.Column<string>(type: "TEXT", maxLength: 30, nullable: false),
-                    apellido = table.Column<string>(type: "TEXT", maxLength: 30, nullable: false),
-                    id_tipo_doc = table.Column<int>(type: "INTEGER", nullable: false),
-                    num_doc = table.Column<string>(type: "TEXT", maxLength: 20, nullable: false),
-                    cuil = table.Column<string>(type: "TEXT", maxLength: 10, nullable: false),
-                    calle = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
-                    altura = table.Column<string>(type: "TEXT", maxLength: 30, nullable: false),
-                    id_localidad = table.Column<int>(type: "INTEGER", nullable: false),
-                    id_genero = table.Column<int>(type: "INTEGER", nullable: false),
-                    correo = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
-                    FechaIngreso = table.Column<DateTime>(type: "TEXT", nullable: false)
+                    id_persona = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    legajo = table.Column<int>(type: "int", nullable: false),
+                    nombre = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    apellido = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    id_tipo_doc = table.Column<int>(type: "int", nullable: false),
+                    num_doc = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    cuil = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: false),
+                    calle = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    altura = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    id_localidad = table.Column<int>(type: "int", nullable: false),
+                    id_genero = table.Column<int>(type: "int", nullable: false),
+                    correo = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    FechaIngreso = table.Column<DateTime>(type: "datetime2", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -286,11 +286,11 @@ namespace DataAccess.Migrations
                 name: "contactos",
                 columns: table => new
                 {
-                    id_contacto = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    email = table.Column<string>(type: "TEXT", nullable: false),
-                    celular = table.Column<string>(type: "TEXT", nullable: false),
-                    id_persona = table.Column<int>(type: "INTEGER", nullable: false)
+                    id_contacto = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    celular = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    id_persona = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/DataAccess/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/DataAccess/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -3,6 +3,7 @@ using System;
 using DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -15,27 +16,33 @@ namespace DataAccess.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.7");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "9.0.7")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("DataAccess.Entities.Contacto", b =>
                 {
                     b.Property<int>("IdContacto")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_contacto");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdContacto"));
 
                     b.Property<string>("Celular")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasColumnName("celular");
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasColumnName("email");
 
                     b.Property<int>("IdPersona")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_persona");
 
                     b.HasKey("IdContacto");
@@ -49,13 +56,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdGenero")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_genero");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdGenero"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(25)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(25)")
                         .HasColumnName("genero");
 
                     b.HasKey("IdGenero");
@@ -67,16 +76,18 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdHistorial")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdHistorial"));
 
                     b.Property<byte[]>("ContrasenaScript")
                         .IsRequired()
-                        .HasColumnType("BLOB")
+                        .HasColumnType("varbinary(max)")
                         .HasColumnName("contrasena_script");
 
                     b.Property<int>("IdUsuario")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
                     b.HasKey("IdHistorial");
@@ -88,17 +99,19 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdLocalidad")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_localidad");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdLocalidad"));
+
                     b.Property<int>("IdPartido")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_partido");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("localidad");
 
                     b.HasKey("IdLocalidad");
@@ -112,17 +125,19 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPartido")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_partido");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPartido"));
+
                     b.Property<int>("IdProvincia")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_provincia");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("partido");
 
                     b.HasKey("IdPartido");
@@ -136,19 +151,21 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPermiso")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_permiso");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPermiso"));
 
                     b.Property<string>("Descripcion")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(200)")
                         .HasColumnName("descripcion");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("permiso");
 
                     b.HasKey("IdPermiso");
@@ -159,15 +176,15 @@ namespace DataAccess.Migrations
             modelBuilder.Entity("DataAccess.Entities.PermisoUsuario", b =>
                 {
                     b.Property<int>("IdUsuario")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
                     b.Property<int>("IdPermiso")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_permiso");
 
                     b.Property<DateTime>("FechaVencimiento")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("fecha_vencimiento");
 
                     b.HasKey("IdUsuario", "IdPermiso");
@@ -179,68 +196,70 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPersona")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_persona");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPersona"));
 
                     b.Property<string>("Altura")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("altura");
 
                     b.Property<string>("Apellido")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("apellido");
 
                     b.Property<string>("Calle")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("calle");
 
                     b.Property<string>("Correo")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(100)")
                         .HasColumnName("correo");
 
                     b.Property<string>("Cuil")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(10)")
                         .HasColumnName("cuil");
 
                     b.Property<DateTime>("FechaIngreso")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("IdGenero")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_genero");
 
                     b.Property<int>("IdLocalidad")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_localidad");
 
                     b.Property<int>("IdTipoDoc")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_tipo_doc");
 
                     b.Property<int>("Legajo")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("legajo");
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("nombre");
 
                     b.Property<string>("NumDoc")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(20)")
                         .HasColumnName("num_doc");
 
                     b.HasKey("IdPersona");
@@ -258,39 +277,41 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPolitica")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_politica");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPolitica"));
+
                     b.Property<bool>("Autenticacion2FA")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("autenticacion_2fa");
 
                     b.Property<int>("CantPreguntas")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("cant_preguntas");
 
                     b.Property<bool>("CaracterEspecial")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("caracter_especial");
 
                     b.Property<bool>("LetrasYNumeros")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("letras_y_numeros");
 
                     b.Property<bool>("MayusYMinus")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("mayus_y_minus");
 
                     b.Property<int>("MinCaracteres")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("min_caracteres");
 
                     b.Property<bool>("NoRepetirAnteriores")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("no_repetir_anteriores");
 
                     b.Property<bool>("SinDatosPersonales")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("sin_datos_personales");
 
                     b.HasKey("IdPolitica");
@@ -302,13 +323,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdPregunta")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_pregunta");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdPregunta"));
 
                     b.Property<string>("Pregunta")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(255)")
                         .HasColumnName("pregunta");
 
                     b.HasKey("IdPregunta");
@@ -320,13 +343,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdProvincia")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_provincia");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdProvincia"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("provincia");
 
                     b.HasKey("IdProvincia");
@@ -337,16 +362,16 @@ namespace DataAccess.Migrations
             modelBuilder.Entity("DataAccess.Entities.RespuestaSeguridad", b =>
                 {
                     b.Property<int>("IdUsuario")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
                     b.Property<int>("IdPregunta")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_pregunta");
 
                     b.Property<string>("Respuesta")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasColumnName("respuesta");
 
                     b.HasKey("IdUsuario", "IdPregunta");
@@ -358,13 +383,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdRol")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_rol");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdRol"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(50)")
                         .HasColumnName("rol");
 
                     b.HasKey("IdRol");
@@ -375,11 +402,11 @@ namespace DataAccess.Migrations
             modelBuilder.Entity("DataAccess.Entities.RolPermiso", b =>
                 {
                     b.Property<int>("IdRol")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_rol");
 
                     b.Property<int>("IdPermiso")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_permiso");
 
                     b.HasKey("IdRol", "IdPermiso");
@@ -393,13 +420,15 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdTipoDoc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_tipo_doc");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdTipoDoc"));
 
                     b.Property<string>("Nombre")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("tipo_doc");
 
                     b.HasKey("IdTipoDoc");
@@ -411,43 +440,45 @@ namespace DataAccess.Migrations
                 {
                     b.Property<int>("IdUsuario")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_usuario");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdUsuario"));
+
                     b.Property<bool>("CambioContrasenaObligatorio")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("CambioContrasenaObligatorio");
 
                     b.Property<byte[]>("ContrasenaScript")
                         .IsRequired()
-                        .HasColumnType("BLOB")
+                        .HasColumnType("varbinary(max)")
                         .HasColumnName("contrasena_script");
 
                     b.Property<DateTime?>("FechaBloqueo")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("fecha_bloqueo");
 
                     b.Property<DateTime>("FechaUltimoCambio")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("fecha_ultimo_cambio");
 
                     b.Property<int>("IdPersona")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_persona");
 
                     b.Property<int>("IdRol")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id_rol");
 
                     b.Property<string>("NombreUsuarioBloqueo")
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("nombre_usuario_bloqueo");
 
                     b.Property<string>("UsuarioNombre")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(30)")
                         .HasColumnName("usuario");
 
                     b.HasKey("IdUsuario");


### PR DESCRIPTION
- Modifica la entidad Usuario para permitir valores nulos en FechaBloqueo y NombreUsuarioBloqueo.
- Revierte la configuración de la base de datos a SQL Server.
- Crea una nueva migración para SQL Server con la corrección.