### PR TITLE
feat: Implement dynamic and configurable security questions

### DIFF
--- a/create_database_login2_corrected_v2.sql
+++ b/create_database_login2_corrected_v2.sql
@@ -876,6 +876,14 @@ GO
 EXEC sp_insert_rol @rol = 'Administrador';
 GO
 
+-- Insert Preguntas de Seguridad
+EXEC sp_insert_pregunta_seguridad @pregunta = '¿Cuál era el nombre de tu primera mascota?';
+EXEC sp_insert_pregunta_seguridad @pregunta = '¿Cuál es el apellido de soltera de tu madre?';
+EXEC sp_insert_pregunta_seguridad @pregunta = '¿Cómo se llamaba tu escuela primaria?';
+EXEC sp_insert_pregunta_seguridad @pregunta = '¿En qué ciudad naciste?';
+EXEC sp_insert_pregunta_seguridad @pregunta = '¿Cuál es tu libro favorito?';
+GO
+
 -- Insert Persona for Admin
 DECLARE @id_tipo_doc INT, @id_localidad INT, @id_genero INT;
 SELECT @id_tipo_doc = id_tipo_doc FROM tipo_doc WHERE tipo_doc = 'DNI';

--- a/src/BusinessLogic/Services/IUserService.cs
+++ b/src/BusinessLogic/Services/IUserService.cs
@@ -10,7 +10,7 @@ namespace BusinessLogic.Services
         void CrearPersona(PersonaRequest request);
         void CrearUsuario(UserRequest request);
         UserResponse? Authenticate(string username, string password);
-        void RecuperarContrasena(string username, string[] respuestas);
+        void RecuperarContrasena(string username, Dictionary<int, string> respuestas);
         void CambiarContrasena(string username, string newPassword);
         List<TipoDoc> GetTiposDoc();
         List<Localidad> GetLocalidades();
@@ -20,6 +20,7 @@ namespace BusinessLogic.Services
         PoliticaSeguridad? GetPoliticaSeguridad();
         void UpdatePoliticaSeguridad(PoliticaSeguridad politica);
         List<Usuario> GetAllUsers();
-        void GuardarRespuestasSeguridad(string username, string[] respuestas);
+        void GuardarRespuestasSeguridad(string username, Dictionary<int, string> respuestas);
+        List<PreguntaSeguridad> GetPreguntasSeguridad();
     }
 }

--- a/src/DataAccess/Repositories/IUserRepository.cs
+++ b/src/DataAccess/Repositories/IUserRepository.cs
@@ -27,5 +27,6 @@ namespace DataAccess.Repositories
         List<HistorialContrasena> GetHistorialContrasenasByUsuarioId(int idUsuario);
         void AddHistorialContrasena(HistorialContrasena historial);
         void AddRespuestaSeguridad(RespuestaSeguridad respuesta);
+        List<PreguntaSeguridad> GetPreguntasSeguridad();
     }
 }

--- a/src/DataAccess/Repositories/UserRepository.cs
+++ b/src/DataAccess/Repositories/UserRepository.cs
@@ -124,5 +124,7 @@ namespace DataAccess.Repositories
             _context.RespuestasSeguridad.Add(respuesta);
             _context.SaveChanges();
         }, "adding security answer");
+
+        public List<PreguntaSeguridad> GetPreguntasSeguridad() => ExecuteDbOperation(() => _context.PreguntasSeguridad.ToList(), "getting all security questions");
     }
 }

--- a/src/Presentation/PreguntasSeguridadForm.Designer.cs
+++ b/src/Presentation/PreguntasSeguridadForm.Designer.cs
@@ -18,77 +18,47 @@ namespace Presentation
 
         private void InitializeComponent()
         {
-            this.lblPregunta1 = new System.Windows.Forms.Label();
-            this.txtRespuesta1 = new System.Windows.Forms.TextBox();
-            this.lblPregunta2 = new System.Windows.Forms.Label();
-            this.txtRespuesta2 = new System.Windows.Forms.TextBox();
             this.btnGuardar = new System.Windows.Forms.Button();
+            this.flowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.SuspendLayout();
-            //
-            // lblPregunta1
-            //
-            this.lblPregunta1.AutoSize = true;
-            this.lblPregunta1.Location = new System.Drawing.Point(12, 15);
-            this.lblPregunta1.Name = "lblPregunta1";
-            this.lblPregunta1.Size = new System.Drawing.Size(158, 15);
-            this.lblPregunta1.TabIndex = 0;
-            this.lblPregunta1.Text = "¿Nombre de su primer mascota?";
-            //
-            // txtRespuesta1
-            //
-            this.txtRespuesta1.Location = new System.Drawing.Point(12, 33);
-            this.txtRespuesta1.Name = "txtRespuesta1";
-            this.txtRespuesta1.Size = new System.Drawing.Size(260, 23);
-            this.txtRespuesta1.TabIndex = 1;
-            //
-            // lblPregunta2
-            //
-            this.lblPregunta2.AutoSize = true;
-            this.lblPregunta2.Location = new System.Drawing.Point(12, 70);
-            this.lblPregunta2.Name = "lblPregunta2";
-            this.lblPregunta2.Size = new System.Drawing.Size(135, 15);
-            this.lblPregunta2.TabIndex = 2;
-            this.lblPregunta2.Text = "¿Lugar de nacimiento?";
-            //
-            // txtRespuesta2
-            //
-            this.txtRespuesta2.Location = new System.Drawing.Point(12, 88);
-            this.txtRespuesta2.Name = "txtRespuesta2";
-            this.txtRespuesta2.Size = new System.Drawing.Size(260, 23);
-            this.txtRespuesta2.TabIndex = 3;
             //
             // btnGuardar
             //
-            this.btnGuardar.Location = new System.Drawing.Point(100, 130);
+            this.btnGuardar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnGuardar.Location = new System.Drawing.Point(397, 226);
             this.btnGuardar.Name = "btnGuardar";
             this.btnGuardar.Size = new System.Drawing.Size(75, 23);
             this.btnGuardar.TabIndex = 4;
             this.btnGuardar.Text = "Guardar";
             this.btnGuardar.UseVisualStyleBackColor = true;
             //
+            // flowLayoutPanel
+            //
+            this.flowLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.flowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanel.Location = new System.Drawing.Point(12, 12);
+            this.flowLayoutPanel.Name = "flowLayoutPanel";
+            this.flowLayoutPanel.Size = new System.Drawing.Size(460, 208);
+            this.flowLayoutPanel.TabIndex = 5;
+            //
             // PreguntasSeguridadForm
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(284, 161);
+            this.ClientSize = new System.Drawing.Size(484, 261);
+            this.Controls.Add(this.flowLayoutPanel);
             this.Controls.Add(this.btnGuardar);
-            this.Controls.Add(this.txtRespuesta2);
-            this.Controls.Add(this.lblPregunta2);
-            this.Controls.Add(this.txtRespuesta1);
-            this.Controls.Add(this.lblPregunta1);
             this.Name = "PreguntasSeguridadForm";
             this.Text = "Preguntas de Seguridad";
+            this.Load += new System.EventHandler(this.PreguntasSeguridadForm_Load);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.Label lblPregunta1;
-        private System.Windows.Forms.TextBox txtRespuesta1;
-        private System.Windows.Forms.Label lblPregunta2;
-        private System.Windows.Forms.TextBox txtRespuesta2;
         private System.Windows.Forms.Button btnGuardar;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel;
     }
 }


### PR DESCRIPTION
This commit refactors the security question feature to be dynamic and configurable, fulfilling the project requirements.

Key changes:
- The system now supports a configurable number of security questions (e.g., you answer 3 out of 5).
- The `preguntas_seguridad` table is now seeded with 5 default questions.
- The Data Access and Business Logic layers have been updated to fetch and save a variable number of questions and answers.
- The `PreguntasSeguridadForm` UI has been completely rebuilt to dynamically generate question selection (ComboBox) and answer (TextBox) fields based on the security policy.
- The UI now includes validation to prevent you from selecting the same question multiple times.
- The password recovery flow has been updated to use the new dynamic security question logic.