### PR TITLE
Fix(ui): Trim password in LoginForm

### DIFF
--- a/src/Presentation/LoginForm.cs
+++ b/src/Presentation/LoginForm.cs
@@ -27,7 +27,7 @@ namespace Presentation
             }
 
             string usuario = txtUsuario.Text.Trim();
-            string contrasena = txtContrasena.Text;
+            string contrasena = txtContrasena.Text.Trim();
 
             var user = _userService.Authenticate(usuario, contrasena);
 


### PR DESCRIPTION
This commit fixes a bug where the login would fail if you entered a password with leading or trailing whitespace. The password string is now trimmed before being sent for authentication.