### PR TITLE
Fix: Correct password hashing to match database

### DIFF
--- a/src/BusinessLogic/Services/UserService.cs
+++ b/src/BusinessLogic/Services/UserService.cs
@@ -234,8 +234,7 @@ namespace BusinessLogic.Services
         {
             using (var sha256 = SHA256.Create())
             {
-                var salted = $"{username}:{password}";
-                return sha256.ComputeHash(Encoding.UTF8.GetBytes(salted));
+                return sha256.ComputeHash(Encoding.UTF8.GetBytes(password));
             }
         }
 


### PR DESCRIPTION
The password hashing function was salting the password with the username, but the database expected an unsalted hash. This caused the login to fail for all users, including the default admin.

The hashing function has been changed to only hash the password, aligning it with the database schema and fixing the login process.