### PR TITLE
Fix: Add default security policy to database schema

### DIFF
--- a/create_database_login2_corrected_v2.sql
+++ b/create_database_login2_corrected_v2.sql
@@ -99,6 +99,11 @@ CREATE TABLE politicas_seguridad (
     sin_datos_personales BIT
 );
 
+-- Insert Default Security Policy
+INSERT INTO politicas_seguridad (min_caracteres, cant_preguntas, mayus_y_minus, letras_y_numeros, caracter_especial, autenticacion_2fa, no_repetir_anteriores, sin_datos_personales)
+VALUES (8, 3, 0, 0, 0, 0, 0, 0);
+GO
+
 -- 10. Usuarios
 CREATE TABLE usuarios (
     id_usuario INT PRIMARY KEY IDENTITY(1,1),


### PR DESCRIPTION
The password validation logic was failing because the `politicas_seguridad` table was created without any default data. This caused the application to load a `null` policy, effectively disabling all password validation rules.

This change adds a default security policy row to the `create_database_login2_corrected_v2.sql` script. This ensures that a valid policy is always present in the database, allowing the password validation logic to be enforced correctly during user creation and password changes.