### PR TITLE
fix: Force layout update on security questions panel

### DIFF
--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -90,6 +90,8 @@ namespace Presentation
                 preguntasLayoutPanel.Controls.Add(label, 0, i);
                 preguntasLayoutPanel.Controls.Add(textBox, 1, i);
             }
+            // Forzar al panel a redibujar su contenido
+            preguntasLayoutPanel.PerformLayout();
         }
 
         private void LimpiarPreguntas()


### PR DESCRIPTION
Even after adding RowStyles, the dynamically added controls for security questions were not appearing. This is a common WinForms issue where the layout does not update automatically after adding controls.

This commit resolves the issue by calling `PerformLayout()` on the `TableLayoutPanel` after all controls have been added. This forces the panel to recalculate its layout and render the new controls, ensuring they become visible to you.