### PR TITLE
refactor: Replace TableLayoutPanel with manual layout for questions

### DIFF
--- a/src/Presentation/RecuperarContrasenaForm.Designer.cs
+++ b/src/Presentation/RecuperarContrasenaForm.Designer.cs
@@ -6,7 +6,7 @@ namespace Presentation
         private System.Windows.Forms.Label lblUsuario;
         private System.Windows.Forms.TextBox txtUsuario;
         private System.Windows.Forms.Button btnContinuar;
-        private System.Windows.Forms.TableLayoutPanel preguntasLayoutPanel;
+        private System.Windows.Forms.Panel preguntasPanel; // Cambiado de TableLayoutPanel a Panel
         private System.Windows.Forms.Button btnRecuperar;
 
         protected override void Dispose(bool disposing)
@@ -21,7 +21,7 @@ namespace Presentation
             this.lblUsuario = new System.Windows.Forms.Label();
             this.txtUsuario = new System.Windows.Forms.TextBox();
             this.btnContinuar = new System.Windows.Forms.Button();
-            this.preguntasLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.preguntasPanel = new System.Windows.Forms.Panel(); // Cambiado
             this.btnRecuperar = new System.Windows.Forms.Button();
             this.SuspendLayout();
             //
@@ -47,19 +47,16 @@ namespace Presentation
             this.btnContinuar.Text = "Continuar";
             this.btnContinuar.UseVisualStyleBackColor = true;
             //
-            // preguntasLayoutPanel
             //
-            this.preguntasLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            // preguntasPanel
+            //
+            this.preguntasPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.preguntasLayoutPanel.AutoScroll = true;
-            this.preguntasLayoutPanel.ColumnCount = 2;
-            this.preguntasLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 40F));
-            this.preguntasLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 60F));
-            this.preguntasLayoutPanel.Location = new System.Drawing.Point(12, 50);
-            this.preguntasLayoutPanel.Name = "preguntasLayoutPanel";
-            this.preguntasLayoutPanel.RowCount = 0;
-            this.preguntasLayoutPanel.Size = new System.Drawing.Size(329, 150);
+            this.preguntasPanel.AutoScroll = true;
+            this.preguntasPanel.Location = new System.Drawing.Point(12, 50);
+            this.preguntasPanel.Name = "preguntasPanel";
+            this.preguntasPanel.Size = new System.Drawing.Size(329, 150);
             //
             // btnRecuperar
             //

--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -42,7 +42,7 @@ namespace Presentation
                 if (_preguntasUsuario.Count > 0)
                 {
                     MostrarPreguntas(_preguntasUsuario);
-                    preguntasLayoutPanel.Visible = true;
+                    preguntasPanel.Visible = true; // Cambiado
                     btnRecuperar.Visible = true;
                     txtUsuario.Enabled = false; // Prevent user from changing username
                     btnContinuar.Enabled = false; // Prevent clicking again
@@ -62,45 +62,42 @@ namespace Presentation
 
         private void MostrarPreguntas(List<PreguntaSeguridad> preguntas)
         {
-            LimpiarPreguntas(); // Limpia controles y estilos de fila anteriores
+            LimpiarPreguntas();
+            int topPosition = 10; // Posición Y inicial
 
-            preguntasLayoutPanel.RowCount = preguntas.Count;
-            for (int i = 0; i < preguntas.Count; i++)
+            foreach (var pregunta in preguntas)
             {
-                var pregunta = preguntas[i];
-
-                // Añadir un estilo de fila para la nueva fila
-                preguntasLayoutPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-
                 var label = new Label
                 {
                     Text = pregunta.Pregunta,
-                    Dock = DockStyle.Fill,
-                    TextAlign = System.Drawing.ContentAlignment.MiddleLeft,
-                    Margin = new Padding(3, 0, 3, 10) // Margen inferior para espaciar
+                    Left = 10,
+                    Top = topPosition,
+                    Width = preguntasPanel.Width - 20, // Ancho completo menos un margen
+                    AutoSize = true // Permitir que el alto se ajuste
                 };
+
+                topPosition += label.Height + 5; // Espacio entre pregunta y respuesta
 
                 var textBox = new TextBox
                 {
-                    Dock = DockStyle.Fill,
-                    Tag = pregunta.IdPregunta, // Store question ID
-                    Margin = new Padding(3, 0, 3, 10) // Margen inferior
+                    Left = 10,
+                    Top = topPosition,
+                    Width = preguntasPanel.Width - 20,
+                    Tag = pregunta.IdPregunta // Guardar el ID de la pregunta
                 };
 
-                preguntasLayoutPanel.Controls.Add(label, 0, i);
-                preguntasLayoutPanel.Controls.Add(textBox, 1, i);
+                topPosition += textBox.Height + 15; // Espacio para la siguiente pregunta
+
+                preguntasPanel.Controls.Add(label);
+                preguntasPanel.Controls.Add(textBox);
             }
-            // Forzar al panel a redibujar su contenido
-            preguntasLayoutPanel.PerformLayout();
         }
 
         private void LimpiarPreguntas()
         {
             _preguntasUsuario.Clear();
-            preguntasLayoutPanel.Controls.Clear();
-            preguntasLayoutPanel.RowStyles.Clear(); // Limpiar los estilos de fila
-            preguntasLayoutPanel.RowCount = 0;
-            preguntasLayoutPanel.Visible = false;
+            preguntasPanel.Controls.Clear(); // Solo limpiar controles
+            preguntasPanel.Visible = false;
             btnRecuperar.Visible = false;
         }
 
@@ -109,7 +106,7 @@ namespace Presentation
             try
             {
                 var respuestas = new Dictionary<int, string>();
-                foreach (Control control in preguntasLayoutPanel.Controls)
+                foreach (Control control in preguntasPanel.Controls)
                 {
                     if (control is TextBox textBox)
                     {


### PR DESCRIPTION
The `TableLayoutPanel` continued to cause rendering issues despite several fixes. To resolve the problem definitively, this commit replaces the `TableLayoutPanel` with a standard `Panel`.

The form logic has been updated to manually calculate the position of each label and textbox, laying them out vertically. This provides direct control over the rendering process and avoids the complexities and potential bugs of the `TableLayoutPanel`'s layout engine.