### PR TITLE
fix: Force form refresh to show security questions

### DIFF
--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -42,10 +42,11 @@ namespace Presentation
                 if (_preguntasUsuario.Count > 0)
                 {
                     MostrarPreguntas(_preguntasUsuario);
-                    preguntasPanel.Visible = true; // Cambiado
+                    preguntasPanel.Visible = true;
                     btnRecuperar.Visible = true;
                     txtUsuario.Enabled = false; // Prevent user from changing username
                     btnContinuar.Enabled = false; // Prevent clicking again
+                    this.Refresh(); // Forzar redibujo de todo el formulario
                 }
                 else
                 {


### PR DESCRIPTION
The panel containing security questions and answers was still not rendering despite previous fixes. This suggests the issue is with the parent form's paint cycle not updating correctly after child controls are made visible.

This commit adds a call to `this.Refresh()` on the form itself after the panel is populated and made visible. This forces the entire form and all its child controls to invalidate and redraw immediately, ensuring the newly visible panel and its contents are rendered.