### PR TITLE
I've fixed a compile error that was caused by a leftover reference to…

### DIFF
--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -18,7 +18,7 @@ namespace Presentation
             _userService = userService;
 
             // Configure initial state
-            preguntasLayoutPanel.Visible = false;
+            preguntasPanel.Visible = false;
             btnRecuperar.Visible = false;
 
             // Wire up events


### PR DESCRIPTION
… the old `preguntasLayoutPanel` in the form's constructor. This reference was missed during the refactoring to a standard `Panel`.

I've corrected the name to `preguntasPanel`, resolving the build failure.