### PR TITLE
Fix: Correct UI rendering in password recovery form

### DIFF
--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -46,7 +46,7 @@ namespace Presentation
                     btnRecuperar.Visible = true;
                     txtUsuario.Enabled = false; // Prevent user from changing username
                     btnContinuar.Enabled = false; // Prevent clicking again
-                    this.Refresh(); // Forzar redibujo de todo el formulario
+                    preguntasPanel.PerformLayout();
                 }
                 else
                 {
@@ -66,31 +66,39 @@ namespace Presentation
             LimpiarPreguntas();
             int topPosition = 10; // Posición Y inicial
 
-            foreach (var pregunta in preguntas)
+            preguntasPanel.SuspendLayout();
+            try
             {
-                var label = new Label
+                foreach (var pregunta in preguntas)
                 {
-                    Text = pregunta.Pregunta,
-                    Left = 10,
-                    Top = topPosition,
-                    Width = preguntasPanel.Width - 20, // Ancho completo menos un margen
-                    AutoSize = true // Permitir que el alto se ajuste
-                };
+                    var label = new Label
+                    {
+                        Text = pregunta.Pregunta,
+                        Left = 10,
+                        Top = topPosition,
+                        Width = preguntasPanel.Width - 20, // Ancho completo menos un margen
+                        AutoSize = true // Permitir que el alto se ajuste
+                    };
 
-                topPosition += label.Height + 5; // Espacio entre pregunta y respuesta
+                    topPosition += label.Height + 5; // Espacio entre pregunta y respuesta
 
-                var textBox = new TextBox
-                {
-                    Left = 10,
-                    Top = topPosition,
-                    Width = preguntasPanel.Width - 20,
-                    Tag = pregunta.IdPregunta // Guardar el ID de la pregunta
-                };
+                    var textBox = new TextBox
+                    {
+                        Left = 10,
+                        Top = topPosition,
+                        Width = preguntasPanel.Width - 20,
+                        Tag = pregunta.IdPregunta // Guardar el ID de la pregunta
+                    };
 
-                topPosition += textBox.Height + 15; // Espacio para la siguiente pregunta
+                    topPosition += textBox.Height + 15; // Espacio para la siguiente pregunta
 
-                preguntasPanel.Controls.Add(label);
-                preguntasPanel.Controls.Add(textBox);
+                    preguntasPanel.Controls.Add(label);
+                    preguntasPanel.Controls.Add(textBox);
+                }
+            }
+            finally
+            {
+                preguntasPanel.ResumeLayout(performLayout: true);
             }
         }
 


### PR DESCRIPTION
The security questions were not being displayed because the panel containing them was not being redrawn correctly after they were dynamically added.

This change addresses the issue by:
- Replacing the generic `this.Refresh()` call with a more specific `preguntasPanel.PerformLayout()` to force the panel to update its layout.
- Wrapping the dynamic control creation in `SuspendLayout()` and `ResumeLayout()` calls, which is a WinForms best practice to ensure proper rendering and prevent flickering.