### PR TITLE
Fix: Prevent UI freeze during password recovery

### DIFF
--- a/src/BusinessLogic/Services/IUserService.cs
+++ b/src/BusinessLogic/Services/IUserService.cs
@@ -1,5 +1,6 @@
 // src/BusinessLogic/Services/IUserService.cs
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using BusinessLogic.Models;
 using DataAccess.Entities;
 
@@ -10,7 +11,7 @@ namespace BusinessLogic.Services
         void CrearPersona(PersonaRequest request);
         void CrearUsuario(UserRequest request);
         UserResponse? Authenticate(string username, string password);
-        void RecuperarContrasena(string username, Dictionary<int, string> respuestas);
+        Task RecuperarContrasena(string username, Dictionary<int, string> respuestas);
         void CambiarContrasena(string username, string newPassword);
         List<TipoDoc> GetTiposDoc();
         List<Localidad> GetLocalidades();

--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -100,36 +100,39 @@ namespace Presentation
             grpUsuario.Enabled = true;
         }
 
-        private void BtnRecuperar_Click(object? sender, EventArgs e)
+        private async void BtnRecuperar_Click(object? sender, EventArgs e)
         {
-            try
+            var respuestas = new Dictionary<int, string>();
+            foreach (Control control in pnlPreguntas.Controls)
             {
-                var respuestas = new Dictionary<int, string>();
-                foreach (Control control in pnlPreguntas.Controls)
+                if (control is TextBox textBox)
                 {
-                    if (control is TextBox textBox)
+                    if (string.IsNullOrWhiteSpace(textBox.Text))
                     {
-                        if (string.IsNullOrWhiteSpace(textBox.Text))
-                        {
-                            MessageBox.Show("Por favor, responda todas las preguntas de seguridad.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                            return;
-                        }
+                        MessageBox.Show("Por favor, responda todas las preguntas de seguridad.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
 
-                        if (textBox.Tag is int idPregunta)
-                        {
-                            respuestas.Add(idPregunta, textBox.Text.Trim());
-                        }
+                    if (textBox.Tag is int idPregunta)
+                    {
+                        respuestas.Add(idPregunta, textBox.Text.Trim());
                     }
                 }
+            }
 
-                if (respuestas.Count != _preguntasUsuario.Count)
-                {
-                     MessageBox.Show("No se pudieron recolectar todas las respuestas. Intente de nuevo.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                     return;
-                }
+            if (respuestas.Count != _preguntasUsuario.Count)
+            {
+                 MessageBox.Show("No se pudieron recolectar todas las respuestas. Intente de nuevo.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                 return;
+            }
 
+            btnRecuperar.Enabled = false;
+            this.Cursor = Cursors.WaitCursor;
+
+            try
+            {
                 string usuario = txtUsuario.Text.Trim();
-                _userService.RecuperarContrasena(usuario, respuestas);
+                await _userService.RecuperarContrasena(usuario, respuestas);
 
                 MessageBox.Show("Si las respuestas proporcionadas son correctas, se ha enviado una nueva contraseña a su dirección de correo electrónico.", "Recuperación Exitosa", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 DialogResult = DialogResult.OK;
@@ -142,6 +145,11 @@ namespace Presentation
             catch (Exception ex)
             {
                 MessageBox.Show($"Se produjo un error inesperado durante la recuperación: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                btnRecuperar.Enabled = true;
+                this.Cursor = Cursors.Default;
             }
         }
     }


### PR DESCRIPTION
The application was freezing because the email sending operation was being called synchronously on the UI thread, leading to a deadlock.

This commit refactors the password recovery process to be fully asynchronous:
- `IUserService` and `UserService` now have an `async Task RecuperarContrasena` method.
- The blocking `.GetAwaiter().GetResult()` call in `UserService` has been replaced with `await`.
- The `BtnRecuperar_Click` event handler in `RecuperarContrasenaForm` is now `async void` and awaits the service call, with UI feedback to prevent user confusion and repeated clicks.