### PR TITLE
feat: Add 'Usuario' role to database

### DIFF
--- a/create_database_login2_corrected_v2.sql
+++ b/create_database_login2_corrected_v2.sql
@@ -956,6 +956,7 @@ GO
 -- Step 7: Insert Admin User
 -- Insert Rol "Administrador"
 EXEC sp_insert_rol @rol = 'Administrador';
+EXEC sp_insert_rol @rol = 'Usuario';
 GO
 
 -- Insert Preguntas de Seguridad


### PR DESCRIPTION
Adds the 'Usuario' (User) role to the database creation script.

The application was already configured to handle different roles, but only the 'Administrador' (Administrator) role was being created. This change adds the 'Usuario' role to the initial data seeding, allowing for the creation of non-administrator users.