### PR TITLE
fix: Correct email service method call during user creation

### DIFF
--- a/src/BusinessLogic/Services/UserService.cs
+++ b/src/BusinessLogic/Services/UserService.cs
@@ -130,7 +130,7 @@ namespace BusinessLogic.Services
             _userRepository.AddUsuario(usuario);
 
             // Enviar la contraseña generada por correo
-            var task = _emailService.SendEmailAsync(persona.Correo, "Bienvenido al Sistema", $"Su contraseña temporal es: {passwordToUse}");
+            var task = _emailService.SendPasswordResetEmailAsync(persona.Correo, passwordToUse);
             task.ContinueWith(t => {
                 // Log exception if email sending fails
                 if (t.IsFaulted)


### PR DESCRIPTION
This commit resolves a build failure that occurred when creating a new user. The `CrearUsuario` method was calling a non-existent method (`SendEmailAsync`) on the `IEmailService` interface.

The code has been corrected to use the available `SendPasswordResetEmailAsync` method, which aligns with the functionality of sending an initial, temporary password to a new user.