### PR TITLE
fix(build): Resolve compilation errors and warnings

### DIFF
--- a/src/BusinessLogic/Services/UserService.cs
+++ b/src/BusinessLogic/Services/UserService.cs
@@ -205,27 +205,30 @@ namespace BusinessLogic.Services
             }, "authenticating user");
         }
 
-        public async Task<UserResponse?> Validate2faAsync(string username, string code)
+        public Task<UserResponse?> Validate2faAsync(string username, string code)
         {
-            return await ExecuteServiceOperationAsync<UserResponse?>(async () =>
+            return ExecuteServiceOperationAsync<UserResponse?>(() =>
             {
                 if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(code))
-                    return null;
+                {
+                    return Task.FromResult<UserResponse?>(null);
+                }
 
                 var usuario = _userRepository.GetUsuarioByNombreUsuario(username);
                 if (usuario == null || usuario.Codigo2FA != code || usuario.Codigo2FAExpiracion < DateTime.UtcNow)
                 {
-                    return null;
+                    return Task.FromResult<UserResponse?>(null);
                 }
 
                 _userRepository.Set2faCode(username, null, null);
 
-                return new UserResponse
+                var userResponse = new UserResponse
                 {
                     Username = usuario.UsuarioNombre,
                     Rol = usuario.Rol?.Nombre,
                     CambioContrasenaObligatorio = usuario.CambioContrasenaObligatorio
                 };
+                return Task.FromResult(userResponse);
             }, "validating 2FA");
         }
 

--- a/src/Presentation/frmError.Designer.cs
+++ b/src/Presentation/frmError.Designer.cs
@@ -110,12 +110,5 @@ namespace Presentation
         }
 
         #endregion
-
-        private System.Windows.Forms.Label lblMessage;
-        private RoundedTextBox txtMessage;
-        private System.Windows.Forms.Label lblExceptionType;
-        private RoundedTextBox txtExceptionType;
-        private System.Windows.Forms.Label lblStackTrace;
-        private RoundedTextBox txtStackTrace;
     }
 }

--- a/src/Services/Controllers/AuthController.cs
+++ b/src/Services/Controllers/AuthController.cs
@@ -24,19 +24,21 @@ namespace Services.Controllers
 
         // src/Services/Controllers/AuthController.cs (assumed snippet around line 36)
         [HttpPost("login")]
-        public IActionResult Login([FromBody] LoginRequest request)
+        public async Task<IActionResult> Login([FromBody] LoginRequest request)
         {
-            // La contraseña ya viene encriptada desde el cliente
-            var user = _userService.Authenticate(request.Username, request.Password);
-            if (user == null)
+            var authResult = await _userService.AuthenticateAsync(request.Username, request.Password);
+
+            if (!authResult.Success || authResult.User == null)
                 return Unauthorized("Invalid credentials");
 
-            // Add null check for user.Rol
+            var user = authResult.User;
+
             var response = new
             {
                 Username = user.Username,
                 Rol = user.Rol ?? "Unknown",
-                CambioContrasenaObligatorio = user.CambioContrasenaObligatorio
+                CambioContrasenaObligatorio = user.CambioContrasenaObligatorio,
+                Requires2fa = authResult.Requires2fa
             };
             return Ok(response);
         }


### PR DESCRIPTION
This commit addresses several compilation errors and a warning that arose after the major UI revamp.

- **CS0102: Duplicate Definitions in `frmError.Designer.cs`**: Removed duplicate field declarations for controls that were present both at the top of the class and after the `#endregion` directive.

- **CS1061: Missing Method in `AuthController.cs`**: Corrected the call to `_userService.Authenticate` to be `await _userService.AuthenticateAsync`, and updated the `Login` method to be asynchronous to handle the `Task` result.

- **CS1998: Async Warning in `UserService.cs`**: Fixed the `Validate2faAsync` method, which was marked as `async` but contained no `await` calls. The `async` keyword was removed from the method and its inner lambda, and synchronous return values are now correctly wrapped in `Task.FromResult` to match the required interface signature.