### PR TITLE
Fix(Presentation): Correct 2FA post-verification logic

### DIFF
--- a/src/Presentation/LoginForm.cs
+++ b/src/Presentation/LoginForm.cs
@@ -40,9 +40,7 @@ namespace Presentation
                     var twoFactorForm = new TwoFactorAuthForm(_userService, username);
                     if (twoFactorForm.ShowDialog() == DialogResult.OK)
                     {
-                        // Re-fetch user details after successful 2FA
-                        var finalAuthResult = await _userService.AuthenticateAsync(username, password);
-                        user = finalAuthResult.User;
+                        user = twoFactorForm.User;
                     }
                     else
                     {

--- a/src/Presentation/TwoFactorAuthForm.cs
+++ b/src/Presentation/TwoFactorAuthForm.cs
@@ -10,6 +10,8 @@ namespace Presentation
         private readonly IUserService _userService;
         private readonly string _username;
 
+        public BusinessLogic.Models.UserResponse? User { get; private set; }
+
         public TwoFactorAuthForm(IUserService userService, string username)
         {
             InitializeComponent();
@@ -26,9 +28,9 @@ namespace Presentation
                 return;
             }
 
-            var user = await _userService.Validate2faAsync(_username, txtCodigo.Text.Trim());
+            User = await _userService.Validate2faAsync(_username, txtCodigo.Text.Trim());
 
-            if (user != null)
+            if (User != null)
             {
                 this.DialogResult = DialogResult.OK;
                 this.Close();


### PR DESCRIPTION
This commit fixes a bug in the two-factor authentication flow where an unexpected error would occur after a successful 2FA code verification.

The issue was caused by the `LoginForm` re-authenticating you after the 2FA form was successfully completed. This second authentication attempt would trigger a new 2FA code generation, leading to a state where you were not fully authenticated.

The fix involves:
- Modifying the `TwoFactorAuthForm` to expose the successfully authenticated user object.
- Updating the `LoginForm` to use this user object from the 2FA form instead of calling the authentication service again.