### PR TITLE
Fix: Add missing parameters to AddPersona method

### DIFF
--- a/create_database_login2_corrected_v2.sql
+++ b/create_database_login2_corrected_v2.sql
@@ -317,16 +317,17 @@ CREATE PROCEDURE sp_insert_persona
     @id_localidad INT,
     @id_genero INT,
     @correo VARCHAR(100),
-    @celular VARCHAR(30)
+    @celular VARCHAR(30),
+    @fecha_ingreso DATETIME
 AS
 BEGIN
     INSERT INTO personas (
         legajo, nombre, apellido, id_tipo_doc, num_doc, fecha_nacimiento,
-        cuil, calle, altura, id_localidad, id_genero, correo, celular
+        cuil, calle, altura, id_localidad, id_genero, correo, celular, fecha_ingreso
     )
     VALUES (
         @legajo, @nombre, @apellido, @id_tipo_doc, @num_doc, @fecha_nacimiento,
-        @cuil, @calle, @altura, @id_localidad, @id_genero, @correo, @celular
+        @cuil, @calle, @altura, @id_localidad, @id_genero, @correo, @celular, @fecha_ingreso
     )
 END
 GO

--- a/src/DataAccess/Repositories/SqlUserRepository.cs
+++ b/src/DataAccess/Repositories/SqlUserRepository.cs
@@ -322,12 +322,15 @@ namespace DataAccess.Repositories
             p.AddWithValue("@apellido", persona.Apellido);
             p.AddWithValue("@id_tipo_doc", persona.IdTipoDoc);
             p.AddWithValue("@num_doc", persona.NumDoc);
+            p.AddWithValue("@fecha_nacimiento", (object?)persona.FechaNacimiento ?? DBNull.Value);
             p.AddWithValue("@cuil", (object?)persona.Cuil ?? DBNull.Value);
             p.AddWithValue("@calle", (object?)persona.Calle ?? DBNull.Value);
             p.AddWithValue("@altura", (object?)persona.Altura ?? DBNull.Value);
             p.AddWithValue("@id_localidad", persona.IdLocalidad);
             p.AddWithValue("@id_genero", persona.IdGenero);
             p.AddWithValue("@correo", (object?)persona.Correo ?? DBNull.Value);
+            p.AddWithValue("@celular", (object?)persona.Celular ?? DBNull.Value);
+            p.AddWithValue("@fecha_ingreso", persona.FechaIngreso);
         });
 
         public void AddRespuestaSeguridad(RespuestaSeguridad respuesta) => ExecuteNonQuery("sp_insert_respuesta_seguridad", p =>


### PR DESCRIPTION
The AddPersona method in SqlUserRepository was not passing all the required parameters to the sp_insert_persona stored procedure. This caused an unexpected error when creating a new person.

This commit fixes the issue by:
- Updating the sp_insert_persona stored procedure to include the @fecha_ingreso parameter.
- Updating the AddPersona method to pass the @fecha_nacimiento, @celular, and @fecha_ingreso parameters to the stored procedure.