### PR TITLE
I've added a null check for `SelectedValue` in `AdminForm`.

### DIFF
--- a/src/Presentation/AdminForm.cs
+++ b/src/Presentation/AdminForm.cs
@@ -383,6 +383,7 @@ namespace Presentation
                     string.IsNullOrWhiteSpace(txtCalle.Text) ||
                     string.IsNullOrWhiteSpace(txtAltura.Text) ||
                     cbxLocalidad.SelectedItem == null ||
+                    cbxLocalidad.SelectedValue == null ||
                     cbxGenero.SelectedItem == null ||
                     string.IsNullOrWhiteSpace(txtCorreo.Text) ||
                     string.IsNullOrWhiteSpace(txtCelular.Text))


### PR DESCRIPTION
A potential `NullReferenceException` could occur in the `BtnGuardarPersona_Click` event handler if `cbxLocalidad.SelectedValue` is null. This would be caught by the generic exception handler, leading to an "unexpected error" message.

This change adds a null check for `cbxLocalidad.SelectedValue` to provide a more specific error message to you and prevent the `NullReferenceException`.