### PR TITLE
Fix: Increase CUIL length and update stored procedures

### DIFF
--- a/create_database_login2_corrected_v2.sql
+++ b/create_database_login2_corrected_v2.sql
@@ -60,7 +60,7 @@ CREATE TABLE personas (
     id_tipo_doc INT NOT NULL,
     num_doc VARCHAR(20) NOT NULL,
     fecha_nacimiento DATE NULL,
-    cuil VARCHAR(10),
+    cuil VARCHAR(15),
     calle VARCHAR(50),
     altura VARCHAR(30),   
     id_localidad INT NOT NULL,
@@ -311,7 +311,7 @@ CREATE PROCEDURE sp_insert_persona
     @id_tipo_doc INT,
     @num_doc VARCHAR(20),
     @fecha_nacimiento DATE,
-    @cuil VARCHAR(10),
+    @cuil VARCHAR(15),
     @calle VARCHAR(50),
     @altura VARCHAR(30),
     @id_localidad INT,
@@ -342,13 +342,14 @@ CREATE PROCEDURE sp_update_persona
     @id_tipo_doc INT,
     @num_doc VARCHAR(20),
     @fecha_nacimiento DATE,
-    @cuil VARCHAR(10),
+    @cuil VARCHAR(15),
     @calle VARCHAR(50),
     @altura VARCHAR(30),
     @id_localidad INT,
     @id_genero INT,
     @correo VARCHAR(100),
-    @celular VARCHAR(30)
+    @celular VARCHAR(30),
+    @fecha_ingreso DATETIME
 AS
 BEGIN
     UPDATE personas
@@ -364,7 +365,8 @@ BEGIN
         id_localidad = @id_localidad,
         id_genero = @id_genero,
         correo = @correo,
-        celular = @celular
+        celular = @celular,
+        fecha_ingreso = @fecha_ingreso
     WHERE id_persona = @id_persona
 END
 GO


### PR DESCRIPTION
The `cuil` column in the `personas` table was defined as `VARCHAR(10)`, which is too short for a standard 11-digit Argentinian CUIL. This could lead to data truncation and other issues.

Additionally, the `sp_update_persona` stored procedure was missing the `fecha_ingreso` column in its `UPDATE` statement.

This commit fixes these issues by:
- Increasing the `cuil` column length to `VARCHAR(15)` in the `personas` table and in the `sp_insert_persona` and `sp_update_persona` stored procedures.
- Adding the `fecha_ingreso` column to the `sp_update_persona` stored procedure.