### PR TITLE
Fix(tests): Repair broken unit tests for UserService

### DIFF
--- a/tests/BusinessLogic.Tests/BusinessLogic.Tests.csproj
+++ b/tests/BusinessLogic.Tests/BusinessLogic.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BusinessLogic.Tests/UserServiceTests.cs
+++ b/tests/BusinessLogic.Tests/UserServiceTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using BusinessLogic.Models;
+using Microsoft.Extensions.Logging;
 
 public class MockEmailService : IEmailService
 {
@@ -158,7 +159,7 @@ public class UserServiceTests
     {
         _userRepository = new MockUserRepository();
         _emailService = new MockEmailService();
-        _userService = new UserService(_userRepository, _emailService);
+        _userService = new UserService(_userRepository, _emailService, new Microsoft.Extensions.Logging.Abstractions.NullLogger<UserService>());
     }
 
     [Fact]


### PR DESCRIPTION
The unit tests for the BusinessLogic layer were failing to compile due to a missing dependency in the UserService constructor. The UserService was updated to require an ILogger, but the test suite was not updated to provide one.

This change resolves the issue by:
1. Adding the `Microsoft.Extensions.Logging` package reference to the `BusinessLogic.Tests` project, matching the version used in the `BusinessLogic` project.
2. Injecting a `NullLogger<UserService>` instance into the `UserService` constructor within the `UserServiceTests` class.

With this fix, the test suite now compiles and all 7 tests pass successfully.