### PR TITLE
fix(presentation): Corrige warning de posible referencia nula en la b…

### DIFF
--- a/src/Presentation/AdminForm.cs
+++ b/src/Presentation/AdminForm.cs
@@ -153,8 +153,8 @@ namespace Presentation
             var searchText = txtBuscarUsuario.Text.ToLower().Trim();
 
             var filteredUsers = _allUsers.Where(u =>
-                u.Username.ToLower().Contains(searchText) ||
-                u.NombreCompleto.ToLower().Contains(searchText)
+                (u.Username?.ToLower() ?? "").Contains(searchText) ||
+                (u.NombreCompleto?.ToLower() ?? "").Contains(searchText)
             ).ToList();
 
             dgvUsuarios.DataSource = filteredUsers;
@@ -177,9 +177,9 @@ namespace Presentation
             var searchText = txtBuscarPersona.Text.ToLower().Trim();
 
             var filteredPersonas = _allPersonas.Where(p =>
-                p.Nombre.ToLower().Contains(searchText) ||
-                p.Apellido.ToLower().Contains(searchText) ||
-                p.NumDoc.ToLower().Contains(searchText)
+                (p.Nombre?.ToLower() ?? "").Contains(searchText) ||
+                (p.Apellido?.ToLower() ?? "").Contains(searchText) ||
+                (p.NumDoc?.ToLower() ?? "").Contains(searchText)
             ).ToList();
 
             dgvPersonas.DataSource = filteredPersonas;


### PR DESCRIPTION
…úsqueda

Se solucionó el warning CS8602 (desreferencia de una referencia posiblemente nula) que aparecía durante la compilación.

La corrección se aplicó en los métodos de búsqueda de usuarios y personas (`TxtBuscarUsuario_TextChanged` y `TxtBuscarPersona_TextChanged`) en `AdminForm.cs`. Se utilizaron operadores de condición nula (`?.`) y de anulación de nulos (`??`) para asegurar que si una propiedad de texto es nula durante el filtrado, se trate como una cadena vacía en lugar de causar una excepción en tiempo de ejecución.