### PR TITLE
This commit addresses several visual problems you reported:

### DIFF
--- a/src/Presentation/AdminForm.Designer.cs
+++ b/src/Presentation/AdminForm.Designer.cs
@@ -888,11 +888,11 @@ namespace Presentation
             // txtBuscarUsuario
             //
             txtBuscarUsuario.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            txtBuscarUsuario.BackColor = System.Drawing.Color.FromArgb(40, 40, 56);
+            txtBuscarUsuario.BackColor = System.Drawing.SystemColors.Window;
             txtBuscarUsuario.BorderStyle = System.Windows.Forms.BorderStyle.None;
             gestionUsuariosLayout.SetColumnSpan(txtBuscarUsuario, 2);
             txtBuscarUsuario.Font = new System.Drawing.Font("Segoe UI", 10F);
-            txtBuscarUsuario.ForeColor = System.Drawing.Color.White;
+            txtBuscarUsuario.ForeColor = System.Drawing.SystemColors.ControlText;
             txtBuscarUsuario.Location = new System.Drawing.Point(103, 8);
             txtBuscarUsuario.Name = "txtBuscarUsuario";
             txtBuscarUsuario.Size = new System.Drawing.Size(517, 23);
@@ -1023,11 +1023,11 @@ namespace Presentation
             // txtBuscarPersona
             //
             txtBuscarPersona.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            txtBuscarPersona.BackColor = System.Drawing.Color.FromArgb(40, 40, 56);
+            txtBuscarPersona.BackColor = System.Drawing.SystemColors.Window;
             txtBuscarPersona.BorderStyle = System.Windows.Forms.BorderStyle.None;
             gestionPersonasLayout.SetColumnSpan(txtBuscarPersona, 2);
             txtBuscarPersona.Font = new System.Drawing.Font("Segoe UI", 10F);
-            txtBuscarPersona.ForeColor = System.Drawing.Color.White;
+            txtBuscarPersona.ForeColor = System.Drawing.SystemColors.ControlText;
             txtBuscarPersona.Location = new System.Drawing.Point(103, 8);
             txtBuscarPersona.Name = "txtBuscarPersona";
             txtBuscarPersona.Size = new System.Drawing.Size(517, 23);

--- a/src/Presentation/AdminForm.cs
+++ b/src/Presentation/AdminForm.cs
@@ -652,6 +652,16 @@ namespace Presentation
             {
                 _allPersonas = _userService.GetPersonas();
                 dgvPersonas.DataSource = new List<PersonaDto>(_allPersonas);
+
+                dgvPersonas.Columns["IdPersona"].Visible = false;
+                dgvPersonas.Columns["IdTipoDoc"].Visible = false;
+                dgvPersonas.Columns["IdLocalidad"].Visible = false;
+                dgvPersonas.Columns["IdPartido"].Visible = false;
+                dgvPersonas.Columns["IdProvincia"].Visible = false;
+                dgvPersonas.Columns["IdGenero"].Visible = false;
+                dgvPersonas.Columns["Calle"].Visible = false;
+                dgvPersonas.Columns["Altura"].Visible = false;
+                dgvPersonas.Columns["FechaIngreso"].Visible = false;
             }
             catch (Exception ex)
             {
@@ -686,7 +696,14 @@ namespace Presentation
 
 
             // Column and Row sizing
-            dgv.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+            if (dgv.Name == "dgvPersonas")
+            {
+                dgv.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
+            }
+            else
+            {
+                dgv.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+            }
             dgv.RowTemplate.Height = 35;
 
             // Selection

--- a/src/Presentation/frmNotification.Designer.cs
+++ b/src/Presentation/frmNotification.Designer.cs
@@ -24,7 +24,7 @@ namespace Presentation
             // 
             // lblMessage
             // 
-            lblMessage.BackColor = System.Drawing.Color.FromArgb(43, 47, 49);
+            lblMessage.BackColor = System.Drawing.Color.Transparent;
             lblMessage.Dock = System.Windows.Forms.DockStyle.Fill;
             lblMessage.ForeColor = System.Drawing.SystemColors.ControlLightLight;
             lblMessage.Location = new System.Drawing.Point(0, 0);


### PR DESCRIPTION
1.  **Error Message Display**: The custom error notification form (`frmNotification`) appeared to be transparent or just a dark box because the message label's background color was obscuring the form's intended 'Danger' color. This has been fixed by making the label's background transparent.

2.  **Search Bar Contrast**: The search bars in the admin panel had poor contrast. The background and foreground colors have been changed to a standard white background and black text for better readability.

3.  **Personas DataGrid Layout**: The data grid for people (`dgvPersonas`) was cluttered and poorly sized. This was caused by displaying too many columns. The grid now hides non-essential ID and data columns, and the column auto-sizing mode has been adjusted for a cleaner layout.