### PR TITLE
Fix compilation errors in UserManagementService

### DIFF
--- a/src/BusinessLogic/Services/UserManagementService.cs
+++ b/src/BusinessLogic/Services/UserManagementService.cs
@@ -45,6 +45,23 @@ namespace BusinessLogic.Services
             }
         }
 
+        private void ExecuteServiceOperation(Action operation, string operationName)
+        {
+            try
+            {
+                operation();
+            }
+            catch (ValidationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during {OperationName}", operationName);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+            }
+        }
+
         public void CrearPersona(PersonaRequest request) => ExecuteServiceOperation(() =>
         {
             _logger.LogInformation("Iniciando la creación de la persona con legajo: {Legajo}", request.Legajo);


### PR DESCRIPTION
The compiler was unable to infer the type arguments for the generic method `ExecuteServiceOperation<T>` when it was called with a lambda expression that did not return a value.

To fix this, I added a new overload for `ExecuteServiceOperation` that accepts an `Action` delegate. This allows the compiler to correctly resolve the method calls for void-returning lambdas.