### PR TITLE
Fix: Resolve nullable warning in UserManagementServiceTests

### DIFF
--- a/tests/BusinessLogic.Tests/UserManagementServiceTests.cs
+++ b/tests/BusinessLogic.Tests/UserManagementServiceTests.cs
@@ -88,7 +88,7 @@ namespace BusinessLogic.Tests
         {
             // Arrange
             var userDto = new UserDto { Username = "nonexistent", IdRol = 1 };
-            _userRepositoryMock.Setup(r => r.GetUsuarioByNombreUsuario("nonexistent")).Returns((Usuario)null);
+            _userRepositoryMock.Setup(r => r.GetUsuarioByNombreUsuario("nonexistent")).Returns((Usuario?)null);
 
             // Act & Assert
             var ex = Assert.Throws<ValidationException>(() => _sut.UpdateUser(userDto));


### PR DESCRIPTION
This commit resolves a CS8600 warning in the `UserManagementServiceTests` class. The warning was caused by an incorrect cast of a null value to a non-nullable type in a Moq setup. The fix ensures that the nullable return type of the `GetUsuarioByNombreUsuario` method is handled correctly in the test.