### PR TITLE
I have fixed the compilation errors related to service interfaces.

### DIFF
--- a/src/Presentation/CambioContrasenaForm.cs
+++ b/src/Presentation/CambioContrasenaForm.cs
@@ -8,14 +8,16 @@ namespace Presentation
 {
     public partial class CambioContrasenaForm : Form
     {
-        private readonly IUserAuthenticationService _authService;
+        private readonly IPasswordService _passwordService;
+        private readonly ISecurityQuestionService _securityQuestionService;
         private readonly IServiceProvider _serviceProvider;
         private string _username = string.Empty;
 
-        public CambioContrasenaForm(IUserAuthenticationService authService, IServiceProvider serviceProvider)
+        public CambioContrasenaForm(IPasswordService passwordService, ISecurityQuestionService securityQuestionService, IServiceProvider serviceProvider)
         {
             InitializeComponent();
-            _authService = authService;
+            _passwordService = passwordService;
+            _securityQuestionService = securityQuestionService;
             _serviceProvider = serviceProvider;
             btnCambiar.Click += BtnCambiar_Click;
         }
@@ -47,11 +49,11 @@ namespace Presentation
                     return;
                 }
 
-                _authService.CambiarContrasena(_username, nueva, actual);
+                _passwordService.CambiarContrasena(_username, nueva, actual);
                 MessageBox.Show("Contraseña cambiada correctamente.", "Info");
 
-                var user = _authService.GetPreguntasDeUsuario(_username);
-                if (user == null || user.Count == 0)
+                var userQuestions = _securityQuestionService.GetPreguntasDeUsuario(_username);
+                if (userQuestions == null || userQuestions.Count == 0)
                 {
                     using (var preguntasForm = _serviceProvider.GetRequiredService<PreguntasSeguridadForm>())
                     {

--- a/src/Presentation/PreguntasSeguridadForm.cs
+++ b/src/Presentation/PreguntasSeguridadForm.cs
@@ -11,16 +11,16 @@ namespace Presentation
 {
     public partial class PreguntasSeguridadForm : Form
     {
-        private readonly IUserAuthenticationService _authService;
+        private readonly ISecurityQuestionService _securityQuestionService;
         private string _username = string.Empty;
         private List<PreguntaSeguridadDto> _preguntas = new List<PreguntaSeguridadDto>();
         private List<ComboBox> _comboBoxes = new List<ComboBox>();
         private List<RoundedTextBox> _textBoxes = new List<RoundedTextBox>();
 
-        public PreguntasSeguridadForm(IUserAuthenticationService authService)
+        public PreguntasSeguridadForm(ISecurityQuestionService securityQuestionService)
         {
             InitializeComponent();
-            _authService = authService;
+            _securityQuestionService = securityQuestionService;
             btnGuardar.Click += BtnGuardar_Click;
         }
 
@@ -33,8 +33,8 @@ namespace Presentation
         {
             try
             {
-                _preguntas = _authService.GetPreguntasSeguridad();
-                var politica = _authService.GetPoliticaSeguridad();
+                _preguntas = _securityQuestionService.GetPreguntasSeguridad();
+                var politica = _securityQuestionService.GetPoliticaSeguridad();
                 int cantidadPreguntas = politica?.CantPreguntas ?? 3; // Default a 3
 
                 for (int i = 0; i < cantidadPreguntas; i++)
@@ -135,7 +135,7 @@ namespace Presentation
 
             try
             {
-                _authService.GuardarRespuestasSeguridad(_username, respuestas);
+                _securityQuestionService.GuardarRespuestasSeguridad(_username, respuestas);
                 MessageBox.Show("Respuestas de seguridad guardadas exitosamente.", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 DialogResult = DialogResult.OK;
                 Close();

--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -12,13 +12,15 @@ namespace Presentation
 {
     public partial class RecuperarContrasenaForm : Form
     {
-        private readonly IUserAuthenticationService _authService;
+        private readonly IPasswordService _passwordService;
+        private readonly ISecurityQuestionService _securityQuestionService;
         private List<PreguntaSeguridadDto> _preguntasUsuario;
 
-        public RecuperarContrasenaForm(IUserAuthenticationService authService)
+        public RecuperarContrasenaForm(IPasswordService passwordService, ISecurityQuestionService securityQuestionService)
         {
             InitializeComponent();
-            _authService = authService ?? throw new ArgumentNullException(nameof(authService));
+            _passwordService = passwordService ?? throw new ArgumentNullException(nameof(passwordService));
+            _securityQuestionService = securityQuestionService ?? throw new ArgumentNullException(nameof(securityQuestionService));
             _preguntasUsuario = new List<PreguntaSeguridadDto>();
 
             // Wire up events
@@ -37,7 +39,7 @@ namespace Presentation
                 }
 
                 var usuario = txtUsuario.Text.Trim();
-                _preguntasUsuario = _authService.GetPreguntasDeUsuario(usuario);
+                _preguntasUsuario = _securityQuestionService.GetPreguntasDeUsuario(usuario);
 
                 if (_preguntasUsuario != null && _preguntasUsuario.Count > 0)
                 {
@@ -140,7 +142,7 @@ namespace Presentation
             try
             {
                 string usuario = txtUsuario.Text.Trim();
-                await _authService.RecuperarContrasena(usuario, respuestas);
+                await _passwordService.RecuperarContrasena(usuario, respuestas);
 
                 MessageBox.Show("Si las respuestas proporcionadas son correctas, se ha enviado una nueva contraseña a su dirección de correo electrónico.", "Recuperación Exitosa", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 DialogResult = DialogResult.OK;

--- a/src/Presentation/TwoFactorAuthForm.cs
+++ b/src/Presentation/TwoFactorAuthForm.cs
@@ -7,12 +7,12 @@ namespace Presentation
 {
     public partial class TwoFactorAuthForm : Form
     {
-        private readonly IUserAuthenticationService _authService;
+        private readonly IAuthenticationService _authService;
         private string _username = string.Empty;
 
         public AuthenticationResult? AuthResult { get; private set; }
 
-        public TwoFactorAuthForm(IUserAuthenticationService authService)
+        public TwoFactorAuthForm(IAuthenticationService authService)
         {
             InitializeComponent();
             _authService = authService;

--- a/src/Presentation/UserForm.cs
+++ b/src/Presentation/UserForm.cs
@@ -7,12 +7,12 @@ namespace Presentation
 {
     public partial class UserForm : Form
     {
-        private readonly IUserAuthenticationService _authService;
+        private readonly IAuthenticationService _authService;
         private readonly IUserManagementService _managementService;
         private readonly IServiceProvider _serviceProvider;
         private string _username = string.Empty;
 
-        public UserForm(IUserAuthenticationService authService, IUserManagementService managementService, IServiceProvider serviceProvider)
+        public UserForm(IAuthenticationService authService, IUserManagementService managementService, IServiceProvider serviceProvider)
         {
             InitializeComponent();
             _authService = authService;

--- a/src/Services/Controllers/AuthController.cs
+++ b/src/Services/Controllers/AuthController.cs
@@ -9,10 +9,10 @@ namespace Services.Controllers
     [Route("api/auth")]
     public class AuthController : ControllerBase
     {
-        private readonly IUserAuthenticationService _authService;
+        private readonly IAuthenticationService _authService;
         private readonly ITokenService _tokenService;
 
-        public AuthController(IUserAuthenticationService authService, ITokenService tokenService)
+        public AuthController(IAuthenticationService authService, ITokenService tokenService)
         {
             _authService = authService;
             _tokenService = tokenService;


### PR DESCRIPTION
The Presentation and Services layers were attempting to use a non-existent `IUserAuthenticationService` interface. The correct interface was `IAuthenticationService`.

Additionally, several forms in the Presentation layer were calling methods that were not part of `IAuthenticationService`. These methods belonged to `IPasswordService` and `ISecurityQuestionService`.

I resolved these issues by:
- Replacing the incorrect `IUserAuthenticationService` with the correct interfaces in all affected files.
- Updating the constructors of the affected forms in the Presentation layer to inject the correct service interfaces (`IPasswordService` and `ISecurityQuestionService`) as needed.
- Updating the method calls within the forms to use the appropriate service instance.