### PR TITLE
Refactor services to adhere to SOLID principles

### DIFF
--- a/src/BusinessLogic/DependencyInjection.cs
+++ b/src/BusinessLogic/DependencyInjection.cs
@@ -53,11 +53,12 @@ namespace BusinessLogic
             // Register new granular services
             services.AddTransient<IAuthenticationService, AuthenticationService>();
             services.AddTransient<IPasswordService, PasswordService>();
+            services.AddTransient<IPersonaService, PersonaService>();
 
             services.AddTransient<ISecurityQuestionService, SecurityQuestionService>();
             services.AddTransient<ISecurityPolicyService, SecurityPolicyService>();
 
-            services.AddTransient<IUserManagementService, UserManagementService>();
+            services.AddTransient<IUserService, UserManagementService>();
             services.AddTransient<IReferenceDataService, ReferenceDataService>();
 
             return services;

--- a/src/BusinessLogic/Services/IUserManagementService.cs
+++ b/src/BusinessLogic/Services/IUserManagementService.cs
@@ -1,8 +1,0 @@
-namespace BusinessLogic.Services
-{
-    public interface IUserManagementService : IUserService, IPersonaService, ISecurityPolicyService
-    {
-        // This interface now aggregates the smaller, more focused interfaces.
-        // No method signatures are needed here directly.
-    }
-}

--- a/src/BusinessLogic/Services/PersonaService.cs
+++ b/src/BusinessLogic/Services/PersonaService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BusinessLogic.Exceptions;
+using BusinessLogic.Factories;
+using BusinessLogic.Mappers;
+using BusinessLogic.Models;
+using DataAccess.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace BusinessLogic.Services
+{
+    public class PersonaService : IPersonaService
+    {
+        private readonly IPersonaRepository _personaRepository;
+        private readonly ILogger<PersonaService> _logger;
+        private readonly IPersonaFactory _personaFactory;
+
+        public PersonaService(
+            IPersonaRepository personaRepository,
+            ILogger<PersonaService> logger,
+            IPersonaFactory personaFactory)
+        {
+            _personaRepository = personaRepository ?? throw new ArgumentNullException(nameof(personaRepository));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _personaFactory = personaFactory ?? throw new ArgumentNullException(nameof(personaFactory));
+        }
+
+        private T ExecuteServiceOperation<T>(Func<T> operation, string operationName)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (ValidationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during {OperationName}", operationName);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+            }
+        }
+
+        private void ExecuteServiceOperation(Action operation, string operationName)
+        {
+            try
+            {
+                operation();
+            }
+            catch (ValidationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during {OperationName}", operationName);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+            }
+        }
+
+        public Task CrearPersonaAsync(PersonaRequest request)
+        {
+            ExecuteServiceOperation(() =>
+            {
+                _logger.LogInformation("Iniciando la creación de la persona con legajo: {Legajo}", request.Legajo);
+                var persona = _personaFactory.Create(request);
+                _logger.LogInformation("Llamando a AddPersona en el repositorio.");
+                _personaRepository.AddPersona(persona);
+                _logger.LogInformation("Persona creada con éxito en el repositorio.");
+            }, "creating a person");
+            return Task.CompletedTask;
+        }
+
+        public Task UpdatePersonaAsync(PersonaDto personaDto)
+        {
+            ExecuteServiceOperation(() =>
+            {
+                var persona = _personaRepository.GetPersonaById(personaDto.IdPersona)
+                    ?? throw new ValidationException($"Persona with id {personaDto.IdPersona} not found");
+
+                persona.Update(personaDto.Legajo, personaDto.Nombre, personaDto.Apellido, personaDto.IdTipoDoc, personaDto.NumDoc, personaDto.FechaNacimiento, personaDto.Cuil, personaDto.Calle, personaDto.Altura, personaDto.IdLocalidad, personaDto.IdGenero, personaDto.Correo, personaDto.Celular, personaDto.FechaIngreso);
+
+                _personaRepository.UpdatePersona(persona);
+            }, "updating persona");
+            return Task.CompletedTask;
+        }
+
+        public Task DeletePersonaAsync(int personaId)
+        {
+            ExecuteServiceOperation(() => _personaRepository.DeletePersona(personaId), "deleting persona");
+            return Task.CompletedTask;
+        }
+
+        public Task<List<PersonaDto>> GetPersonasAsync()
+        {
+            return Task.FromResult(ExecuteServiceOperation(() =>
+                _personaRepository.GetAllPersonas().Select(p => PersonaMapper.MapToPersonaDto(p)!).ToList(),
+                "getting all people"));
+        }
+
+        public Task<PersonaDto?> GetPersonaByIdAsync(int personaId)
+        {
+            return Task.FromResult(ExecuteServiceOperation(() =>
+            {
+                var persona = _personaRepository.GetPersonaById(personaId);
+                return PersonaMapper.MapToPersonaDto(persona);
+            }, "getting persona by id"));
+        }
+    }
+}

--- a/src/BusinessLogic/Services/UserManagementService.cs
+++ b/src/BusinessLogic/Services/UserManagementService.cs
@@ -15,35 +15,33 @@ using BusinessLogic.Mappers;
 
 namespace BusinessLogic.Services
 {
-    public class UserManagementService : IUserManagementService
+    public class UserManagementService : IUserService
     {
         private readonly IUserRepository _userRepository;
-        private readonly IPersonaRepository _personaRepository;
-        private readonly ISecurityRepository _securityRepository;
+        private readonly IPersonaRepository _personaRepository; // This is needed for user creation
         private readonly IEmailService _emailService;
         private readonly ILogger<UserManagementService> _logger;
-        private readonly IPasswordHasher _passwordHasher;
-        private readonly IPersonaFactory _personaFactory;
         private readonly IUsuarioFactory _usuarioFactory;
+        private readonly IPasswordHasher _passwordHasher;
+        private readonly IPersonaService _personaService;
+
 
         public UserManagementService(
             IUserRepository userRepository,
             IPersonaRepository personaRepository,
-            ISecurityRepository securityRepository,
             IEmailService emailService,
             ILogger<UserManagementService> logger,
+            IUsuarioFactory usuarioFactory,
             IPasswordHasher passwordHasher,
-            IPersonaFactory personaFactory,
-            IUsuarioFactory usuarioFactory)
+            IPersonaService personaService)
         {
             _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
             _personaRepository = personaRepository ?? throw new ArgumentNullException(nameof(personaRepository));
-            _securityRepository = securityRepository ?? throw new ArgumentNullException(nameof(securityRepository));
             _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _passwordHasher = passwordHasher ?? throw new ArgumentNullException(nameof(passwordHasher));
-            _personaFactory = personaFactory ?? throw new ArgumentNullException(nameof(personaFactory));
             _usuarioFactory = usuarioFactory ?? throw new ArgumentNullException(nameof(usuarioFactory));
+            _passwordHasher = passwordHasher ?? throw new ArgumentNullException(nameof(passwordHasher));
+            _personaService = personaService ?? throw new ArgumentNullException(nameof(personaService));
         }
 
         private T ExecuteServiceOperation<T>(Func<T> operation, string operationName)
@@ -113,19 +111,6 @@ namespace BusinessLogic.Services
             }
         }
 
-        public Task CrearPersonaAsync(PersonaRequest request)
-        {
-            ExecuteServiceOperation(() =>
-            {
-                _logger.LogInformation("Iniciando la creación de la persona con legajo: {Legajo}", request.Legajo);
-                var persona = _personaFactory.Create(request);
-                _logger.LogInformation("Llamando a AddPersona en el repositorio.");
-                _personaRepository.AddPersona(persona);
-                _logger.LogInformation("Persona creada con éxito en el repositorio.");
-            }, "creating a person");
-            return Task.CompletedTask;
-        }
-
         public async Task CrearUsuarioAsync(UserRequest request) => await ExecuteServiceOperationAsync(async () =>
         {
             var (usuario, plainPassword) = _usuarioFactory.Create(request);
@@ -137,24 +122,10 @@ namespace BusinessLogic.Services
             await _emailService.SendPasswordResetEmailAsync(persona.Correo!, plainPassword);
         }, "creating a user");
 
-        public PoliticaSeguridadDto? GetPoliticaSeguridad() => ExecuteServiceOperation(() =>
-        {
-            var politica = _securityRepository.GetPoliticaSeguridad();
-            return PoliticaSeguridadMapper.MapToPoliticaSeguridadDto(politica);
-        }, "getting security policy");
-
-        public void UpdatePoliticaSeguridad(PoliticaSeguridadDto politicaDto) => ExecuteServiceOperation(() =>
-        {
-            var politica = _securityRepository.GetPoliticaSeguridad()
-                ?? throw new ValidationException("No se encontró la política de seguridad para actualizar.");
-            politica.Update(politicaDto.MayusYMinus, politicaDto.LetrasYNumeros, politicaDto.CaracterEspecial, politicaDto.Autenticacion2FA, politicaDto.NoRepetirAnteriores, politicaDto.SinDatosPersonales, politicaDto.MinCaracteres, politicaDto.CantPreguntas);
-            _securityRepository.UpdatePoliticaSeguridad(politica);
-        }, "updating security policy");
-
         public async Task<List<UserDto>> GetAllUsersAsync() => await ExecuteServiceOperationAsync(async () =>
         {
             var usuarios = await _userRepository.GetAllUsersAsync();
-            var personas = _personaRepository.GetAllPersonas().ToDictionary(p => p.IdPersona);
+            var personas = (await _personaService.GetPersonasAsync()).ToDictionary(p => p.IdPersona);
 
             return usuarios.Select(u =>
             {
@@ -197,46 +168,10 @@ namespace BusinessLogic.Services
             await _userRepository.DeleteUsuarioAsync(userId),
             "deleting user");
 
-        public Task UpdatePersonaAsync(PersonaDto personaDto)
-        {
-            ExecuteServiceOperation(() =>
-            {
-                var persona = _personaRepository.GetPersonaById(personaDto.IdPersona)
-                    ?? throw new ValidationException($"Persona with id {personaDto.IdPersona} not found");
-
-                persona.Update(personaDto.Legajo, personaDto.Nombre, personaDto.Apellido, personaDto.IdTipoDoc, personaDto.NumDoc, personaDto.FechaNacimiento, personaDto.Cuil, personaDto.Calle, personaDto.Altura, personaDto.IdLocalidad, personaDto.IdGenero, personaDto.Correo, personaDto.Celular, personaDto.FechaIngreso);
-
-                _personaRepository.UpdatePersona(persona);
-            }, "updating persona");
-            return Task.CompletedTask;
-        }
-
-        public Task DeletePersonaAsync(int personaId)
-        {
-            ExecuteServiceOperation(() => _personaRepository.DeletePersona(personaId), "deleting persona");
-            return Task.CompletedTask;
-        }
-
         public async Task<UserDto?> GetUserByUsernameAsync(string username) => await ExecuteServiceOperationAsync(async () =>
         {
             var usuario = await _userRepository.GetUsuarioByNombreUsuarioAsync(username);
             return UserMapper.MapToUserDto(usuario);
         }, "getting user by username");
-
-        public Task<PersonaDto?> GetPersonaByIdAsync(int personaId)
-        {
-            return Task.FromResult(ExecuteServiceOperation(() =>
-            {
-                var persona = _personaRepository.GetPersonaById(personaId);
-                return PersonaMapper.MapToPersonaDto(persona);
-            }, "getting persona by id"));
-        }
-
-        public Task<List<PersonaDto>> GetPersonasAsync()
-        {
-            return Task.FromResult(ExecuteServiceOperation(() =>
-                _personaRepository.GetAllPersonas().Select(p => PersonaMapper.MapToPersonaDto(p)!).ToList(),
-                "getting all people"));
-        }
     }
 }

--- a/src/Presentation/Helpers/DataGridViewManager.cs
+++ b/src/Presentation/Helpers/DataGridViewManager.cs
@@ -9,25 +9,25 @@ namespace Presentation.Helpers
 {
     public class DataGridViewManager
     {
-        private readonly IUserManagementService _managementService;
+        private readonly IUserService _userService;
         private readonly DataGridView _dataGridView;
         private List<UserDto> _allUsers;
         private readonly List<int> _dirtyUserIds = new List<int>();
 
-        public DataGridViewManager(IUserManagementService managementService, DataGridView dataGridView)
+        public DataGridViewManager(IUserService userService, DataGridView dataGridView)
         {
-            _managementService = managementService;
+            _userService = userService;
             _dataGridView = dataGridView;
             _allUsers = new List<UserDto>();
 
             _dataGridView.CellEndEdit += DgvUsuarios_CellEndEdit;
         }
 
-        public void LoadUsers()
+        public async void LoadUsers()
         {
             try
             {
-                _allUsers = _managementService.GetAllUsers();
+                _allUsers = await _userService.GetAllUsersAsync();
                 _dataGridView.DataSource = new List<UserDto>(_allUsers);
                 // Configure columns as needed, this might need to be passed in or handled more generically
             }
@@ -66,7 +66,7 @@ namespace Presentation.Helpers
             }
         }
 
-        public void SaveChanges()
+        public async void SaveChanges()
         {
             try
             {
@@ -75,7 +75,7 @@ namespace Presentation.Helpers
                     var usersToUpdate = userDtos.Where(u => _dirtyUserIds.Contains(u.IdUsuario)).ToList();
                     foreach (var userDto in usersToUpdate)
                     {
-                        _managementService.UpdateUser(userDto);
+                        await _userService.UpdateUserAsync(userDto);
                     }
 
                     if (usersToUpdate.Any())
@@ -97,7 +97,7 @@ namespace Presentation.Helpers
             }
         }
 
-        public void DeleteSelectedUser()
+        public async void DeleteSelectedUser()
         {
             if (_dataGridView.SelectedRows.Count == 0)
             {
@@ -115,7 +115,7 @@ namespace Presentation.Helpers
             {
                 try
                 {
-                    _managementService.DeleteUser(userDto.IdUsuario);
+                    await _userService.DeleteUserAsync(userDto.IdUsuario);
                     MessageBox.Show("Usuario eliminado exitosamente.", "Éxito");
                     LoadUsers();
                 }

--- a/src/Presentation/UserForm.cs
+++ b/src/Presentation/UserForm.cs
@@ -8,15 +8,21 @@ namespace Presentation
     public partial class UserForm : Form
     {
         private readonly IAuthenticationService _authService;
-        private readonly IUserManagementService _managementService;
+        private readonly IUserService _userService;
+        private readonly IPersonaService _personaService;
         private readonly IServiceProvider _serviceProvider;
         private string _username = string.Empty;
 
-        public UserForm(IAuthenticationService authService, IUserManagementService managementService, IServiceProvider serviceProvider)
+        public UserForm(
+            IAuthenticationService authService,
+            IUserService userService,
+            IPersonaService personaService,
+            IServiceProvider serviceProvider)
         {
             InitializeComponent();
             _authService = authService;
-            _managementService = managementService;
+            _userService = userService;
+            _personaService = personaService;
             _serviceProvider = serviceProvider;
 
             btnCambiarContrasena.Click += BtnCambiarContrasena_Click;
@@ -47,12 +53,12 @@ namespace Presentation
             }
         }
 
-        private void BtnMiPerfil_Click(object? sender, EventArgs e)
+        private async void BtnMiPerfil_Click(object? sender, EventArgs e)
         {
-            var user = _managementService.GetUserByUsername(_username);
+            var user = await _userService.GetUserByUsernameAsync(_username);
             if (user != null)
             {
-                var persona = _managementService.GetPersonaById(user.IdPersona);
+                var persona = await _personaService.GetPersonaByIdAsync(user.IdPersona);
                 if (persona != null)
                 {
                     using (var form = _serviceProvider.GetRequiredService<ProfileForm>())

--- a/src/Services/Controllers/UsersController.cs
+++ b/src/Services/Controllers/UsersController.cs
@@ -10,17 +10,17 @@ namespace Services.Controllers
     [ApiController]
     public class UsersController : ControllerBase
     {
-        private readonly IUserManagementService _managementService;
+        private readonly IUserService _userService;
 
-        public UsersController(IUserManagementService managementService)
+        public UsersController(IUserService userService)
         {
-            _managementService = managementService;
+            _userService = userService;
         }
 
         [HttpGet]
-        public ActionResult<List<UserDto>> GetAllUsers()
+        public async Task<ActionResult<List<UserDto>>> GetAllUsers()
         {
-            var users = _managementService.GetAllUsers();
+            var users = await _userService.GetAllUsersAsync();
             return Ok(users);
         }
     }

--- a/tests/BusinessLogic.Tests/PersonaServiceTests.cs
+++ b/tests/BusinessLogic.Tests/PersonaServiceTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+using Moq;
+using System.Threading.Tasks;
+using BusinessLogic.Services;
+using BusinessLogic.Models;
+using BusinessLogic.Factories;
+using DataAccess.Repositories;
+using DataAccess.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace BusinessLogic.Tests
+{
+    public class PersonaServiceTests
+    {
+        private readonly Mock<IPersonaRepository> _personaRepositoryMock;
+        private readonly Mock<ILogger<PersonaService>> _loggerMock;
+        private readonly Mock<IPersonaFactory> _personaFactoryMock;
+        private readonly PersonaService _sut;
+
+        public PersonaServiceTests()
+        {
+            _personaRepositoryMock = new Mock<IPersonaRepository>();
+            _loggerMock = new Mock<ILogger<PersonaService>>();
+            _personaFactoryMock = new Mock<IPersonaFactory>();
+            _sut = new PersonaService(
+                _personaRepositoryMock.Object,
+                _loggerMock.Object,
+                _personaFactoryMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task CrearPersonaAsync_WithValidData_CallsFactoryAndRepository()
+        {
+            // Arrange
+            var personaRequest = new PersonaRequest { Nombre = "Test", Apellido = "Person" };
+            var persona = new Persona(1, "Test", "Person", 1, "12345678", System.DateTime.Now, "20123456789", "Test Street", "123", 1, 1, "test@example.com", "1234567890", System.DateTime.Now);
+            _personaFactoryMock.Setup(f => f.Create(personaRequest)).Returns(persona);
+            _personaRepositoryMock.Setup(r => r.AddPersona(persona));
+
+            // Act
+            await _sut.CrearPersonaAsync(personaRequest);
+
+            // Assert
+            _personaFactoryMock.Verify(f => f.Create(personaRequest), Times.Once);
+            _personaRepositoryMock.Verify(r => r.AddPersona(persona), Times.Once);
+        }
+    }
+}

--- a/tests/BusinessLogic.Tests/SecurityPolicyServiceTests.cs
+++ b/tests/BusinessLogic.Tests/SecurityPolicyServiceTests.cs
@@ -1,0 +1,39 @@
+using Xunit;
+using Moq;
+using BusinessLogic.Services;
+using BusinessLogic.Models;
+using DataAccess.Repositories;
+using DataAccess.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace BusinessLogic.Tests
+{
+    public class SecurityPolicyServiceTests
+    {
+        private readonly Mock<ISecurityRepository> _securityRepositoryMock;
+        private readonly Mock<ILogger<SecurityPolicyService>> _loggerMock;
+        private readonly SecurityPolicyService _sut;
+
+        public SecurityPolicyServiceTests()
+        {
+            _securityRepositoryMock = new Mock<ISecurityRepository>();
+            _loggerMock = new Mock<ILogger<SecurityPolicyService>>();
+            _sut = new SecurityPolicyService(_securityRepositoryMock.Object, _loggerMock.Object);
+        }
+
+        [Fact]
+        public void UpdatePoliticaSeguridad_WhenPolicyExists_CallsRepository()
+        {
+            // Arrange
+            var politicaDto = new PoliticaSeguridadDto { IdPolitica = 1, MinCaracteres = 10, CantPreguntas = 3 };
+            var politica = new PoliticaSeguridad(1, true, true, true, true, true, true, 8, 3);
+            _securityRepositoryMock.Setup(r => r.GetPoliticaSeguridad()).Returns(politica);
+
+            // Act
+            _sut.UpdatePoliticaSeguridad(politicaDto);
+
+            // Assert
+            _securityRepositoryMock.Verify(r => r.UpdatePoliticaSeguridad(It.Is<PoliticaSeguridad>(p => p.MinCaracteres == 10)), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
This commit refactors the monolithic `UserManagementService` into smaller, more focused services (`UserService`, `PersonaService`, `SecurityPolicyService`) to better align with the Single Responsibility Principle.

- Moved persona-related logic to a new `PersonaService`.
- Moved security policy logic to the existing `SecurityPolicyService`.
- Renamed `UserManagementService` to `UserService` internally by having it implement `IUserService` and removed the aggregate `IUserManagementService` interface.
- Updated the Dependency Injection container to register the new services.
- Updated all consumer classes in the `Presentation` (WinForms) and `Services` (Web API) layers to use the new, more granular service interfaces.
- Refactored the unit tests to match the new service structure, including creating new test classes for the new services and fixing the existing tests.