### PR TITLE
Refactor services to adhere to SOLID principles

### DIFF
--- a/src/BusinessLogic/Services/UserManagementService.cs
+++ b/src/BusinessLogic/Services/UserManagementService.cs
@@ -18,7 +18,7 @@ namespace BusinessLogic.Services
     public class UserManagementService : IUserService
     {
         private readonly IUserRepository _userRepository;
-        private readonly IPersonaRepository _personaRepository; // This is needed for user creation
+        private readonly IPersonaRepository _personaRepository;
         private readonly IEmailService _emailService;
         private readonly ILogger<UserManagementService> _logger;
         private readonly IUsuarioFactory _usuarioFactory;

--- a/src/Presentation/CambioContrasenaForm.cs
+++ b/src/Presentation/CambioContrasenaForm.cs
@@ -27,7 +27,7 @@ namespace Presentation
             _username = username;
         }
 
-        private void BtnCambiar_Click(object? sender, EventArgs? e)
+        private async void BtnCambiar_Click(object? sender, EventArgs? e)
         {
             try
             {
@@ -49,10 +49,10 @@ namespace Presentation
                     return;
                 }
 
-                _passwordService.CambiarContrasena(_username, nueva, actual);
+                await _passwordService.CambiarContrasenaAsync(_username, nueva, actual);
                 MessageBox.Show("Contraseña cambiada correctamente.", "Info");
 
-                var userQuestions = _securityQuestionService.GetPreguntasDeUsuario(_username);
+                var userQuestions = await _securityQuestionService.GetPreguntasDeUsuarioAsync(_username);
                 if (userQuestions == null || userQuestions.Count == 0)
                 {
                     using (var preguntasForm = _serviceProvider.GetRequiredService<PreguntasSeguridadForm>())

--- a/src/Presentation/PreguntasSeguridadForm.cs
+++ b/src/Presentation/PreguntasSeguridadForm.cs
@@ -100,7 +100,7 @@ namespace Presentation
             }
         }
 
-        private void BtnGuardar_Click(object? sender, EventArgs e)
+        private async void BtnGuardar_Click(object? sender, EventArgs e)
         {
             var respuestas = new Dictionary<int, string>();
             var selectedQuestions = new HashSet<int>();
@@ -135,7 +135,7 @@ namespace Presentation
 
             try
             {
-                _securityQuestionService.GuardarRespuestasSeguridad(_username, respuestas);
+                await _securityQuestionService.GuardarRespuestasSeguridadAsync(_username, respuestas);
                 MessageBox.Show("Respuestas de seguridad guardadas exitosamente.", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 DialogResult = DialogResult.OK;
                 Close();

--- a/src/Presentation/RecuperarContrasenaForm.cs
+++ b/src/Presentation/RecuperarContrasenaForm.cs
@@ -28,7 +28,7 @@ namespace Presentation
             btnRecuperar.Click += BtnRecuperar_Click;
         }
 
-        private void BtnContinuar_Click(object? sender, EventArgs e)
+        private async void BtnContinuar_Click(object? sender, EventArgs e)
         {
             try
             {
@@ -39,7 +39,7 @@ namespace Presentation
                 }
 
                 var usuario = txtUsuario.Text.Trim();
-                _preguntasUsuario = _securityQuestionService.GetPreguntasDeUsuario(usuario);
+                _preguntasUsuario = await _securityQuestionService.GetPreguntasDeUsuarioAsync(usuario);
 
                 if (_preguntasUsuario != null && _preguntasUsuario.Count > 0)
                 {


### PR DESCRIPTION
This commit refactors the monolithic `UserManagementService` into smaller, more focused services (`UserService`, `PersonaService`, `SecurityPolicyService`) to better align with the Single Responsibility Principle.

- Moved persona-related logic to a new `PersonaService`.
- Moved security policy logic to the existing `SecurityPolicyService`.
- Renamed `UserManagementService` to `UserService` internally by having it implement `IUserService` and removed the aggregate `IUserManagementService` interface.
- Updated the Dependency Injection container to register the new services.
- Updated all consumer classes in the `Presentation` (WinForms) and `Services` (Web API) layers to use the new, more granular service interfaces. This included fixing async/await calls in the UI layer that were causing build errors.
- Refactored the unit tests to match the new service structure, including creating new test classes for the new services and fixing the existing tests.