### PR TITLE
Fix admin first-time password change flow

### DIFF
--- a/create_database_login2_corrected_v2.sql
+++ b/create_database_login2_corrected_v2.sql
@@ -991,7 +991,7 @@ BEGIN
         @nombre_usuario_bloqueo = NULL,
         @fecha_ultimo_cambio = @fecha_ultimo_cambio,
         @id_rol = @id_rol,
-        @CambioContrasenaObligatorio = 0;
+        @CambioContrasenaObligatorio = 1;
 END
 ELSE
 BEGIN

--- a/src/Presentation/CambioContrasenaForm.cs
+++ b/src/Presentation/CambioContrasenaForm.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using BusinessLogic.Services;
 using BusinessLogic.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text;
 
 namespace Presentation
 {
@@ -72,6 +73,16 @@ namespace Presentation
                     errorForm.SetMessage(ex.Message);
                     errorForm.ShowDialog();
                 }
+            }
+            catch (BusinessLogicException ex)
+            {
+                var errorMessage = new StringBuilder(ex.Message);
+                if (ex.InnerException != null)
+                {
+                    errorMessage.AppendLine();
+                    errorMessage.AppendLine($"Detalles: {ex.InnerException.Message}");
+                }
+                MessageBox.Show(errorMessage.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The administrator user was not being forced to change their password on the first login because the `CambioContrasenaObligatorio` flag was incorrectly set to `0` in the database creation script.

This commit corrects the script to set the flag to `1`, ensuring the proper workflow is triggered.

Additionally, the error handling in the password change form has been improved to display more detailed messages from `BusinessLogicException`, which will aid in future debugging.