### PR TITLE
Fix SQL error when logging password history

### DIFF
--- a/src/DataAccess/Entities/Usuario.cs
+++ b/src/DataAccess/Entities/Usuario.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.Data.SqlClient;
 
 namespace DataAccess.Entities
 {
@@ -9,7 +10,7 @@ namespace DataAccess.Entities
     {
         [Key]
         [Column("id_usuario")]
-        public int IdUsuario { get; set; }
+        public int IdUsuario { get; private set; }
 
         [Required]
         [Column("usuario")]
@@ -118,6 +119,32 @@ namespace DataAccess.Entities
         {
             Codigo2FA = code;
             Codigo2FAExpiracion = expiration;
+        }
+
+        public static Usuario FromDataReader(SqlDataReader reader)
+        {
+            var usuario = new Usuario
+            {
+                IdUsuario = (int)reader["id_usuario"],
+                UsuarioNombre = reader["usuario"] as string ?? string.Empty,
+                ContrasenaScript = (byte[])reader["contrasena_script"],
+                IdPersona = (int)reader["id_persona"],
+                FechaBloqueo = (DateTime)reader["fecha_bloqueo"],
+                NombreUsuarioBloqueo = reader["nombre_usuario_bloqueo"] as string,
+                FechaUltimoCambio = (DateTime)reader["fecha_ultimo_cambio"],
+                IdRol = (int)reader["id_rol"],
+                IdPolitica = reader["id_politica"] as int?,
+                CambioContrasenaObligatorio = (bool)reader["CambioContrasenaObligatorio"],
+                Codigo2FA = reader["Codigo2FA"] as string,
+                Codigo2FAExpiracion = reader["Codigo2FAExpiracion"] as DateTime?,
+                FechaExpiracion = reader["FechaExpiracion"] as DateTime?,
+                Rol = new Rol
+                {
+                    IdRol = (int)reader["rol_id_rol"],
+                    Nombre = reader["rol"] as string
+                }
+            };
+            return usuario;
         }
     }
 }

--- a/src/DataAccess/Repositories/SqlUserRepository.cs
+++ b/src/DataAccess/Repositories/SqlUserRepository.cs
@@ -115,13 +115,7 @@ namespace DataAccess.Repositories
 
         private static Usuario MapToUsuario(SqlDataReader reader)
         {
-            return new Usuario(
-                reader["usuario"] as string ?? string.Empty,
-                (byte[])reader["contrasena_script"],
-                (int)reader["id_persona"],
-                (int)reader["id_rol"],
-                reader["id_politica"] as int?
-            );
+            return Usuario.FromDataReader(reader);
         }
 
         public async Task AddHistorialContrasenaAsync(HistorialContrasena historial) => await ExecuteNonQueryAsync("sp_historial_contrasena", p =>


### PR DESCRIPTION
A `SqlException` was being thrown when calling `sp_historial_contrasena` due to a foreign key constraint violation. The root cause was an incorrect mapping of the `Usuario` entity from the database.

The `MapToUsuario` method was not reading the `id_usuario` from the `SqlDataReader`, causing the `Usuario` object to have `IdUsuario = 0`. This led to the foreign key violation when trying to insert into the `historial_contrasena` table.

This commit fixes the issue by:
1.  Adding a `FromDataReader` factory method to the `Usuario` entity to handle the mapping from a `SqlDataReader`.
2.  Updating `MapToUsuario` in `SqlUserRepository` to use this new factory method, ensuring all properties are correctly populated.