### PR TITLE
Fix(SqlPersonaRepository): Handle DBNull when loading people

### DIFF
--- a/src/DataAccess/Repositories/SqlPersonaRepository.cs
+++ b/src/DataAccess/Repositories/SqlPersonaRepository.cs
@@ -133,8 +133,8 @@ namespace DataAccess.Repositories
                     )
                     {
                         IdPersona = (int)reader["id_persona"],
-                        TipoDoc = new TipoDoc { IdTipoDoc = (int)reader["id_tipo_doc"], Nombre = reader["TipoDocNombre"].ToString()! },
-                        Genero = new Genero { IdGenero = (int)reader["id_genero"], Nombre = reader["GeneroNombre"].ToString()! }
+                        TipoDoc = new TipoDoc { IdTipoDoc = (int)reader["id_tipo_doc"], Nombre = reader["TipoDocNombre"] as string ?? string.Empty },
+                        Genero = new Genero { IdGenero = (int)reader["id_genero"], Nombre = reader["GeneroNombre"] as string ?? string.Empty }
                     };
 
                     var localidad = new Localidad


### PR DESCRIPTION
This commit fixes a bug that caused an "unexpected error occurred during getting all people" error when the application tries to load the list of people.

The error was caused by improper handling of `DBNull.Value` from the database when mapping the result of a SQL query with `LEFT JOIN`s to C# objects. This could lead to `InvalidCastException` or `NullReferenceException`.

The fix involves:
- Adding checks for `DBNull.Value` before casting foreign key IDs (`IdPartido`, `IdProvincia`).
- Using safe string conversions (`as string ?? string.Empty`) for nullable string columns from joined tables (`TipoDocNombre`, `GeneroNombre`, `LocalidadNombre`, etc.).
- Gracefully handling the creation of nested objects (`Localidad`, `Partido`, `Provincia`) when parts of the data are missing.