### PR TITLE
Fix(SqlPersonaRepository): Correct typo in SQL query

### DIFF
--- a/src/DataAccess/Repositories/SqlPersonaRepository.cs
+++ b/src/DataAccess/Repositories/SqlPersonaRepository.cs
@@ -100,7 +100,7 @@ namespace DataAccess.Repositories
                 FROM
                     personas p
                 LEFT JOIN
-                    tipos_doc td ON p.id_tipo_doc = td.id_tipo_doc
+                    tipo_doc td ON p.id_tipo_doc = td.id_tipo_doc
                 LEFT JOIN
                     localidades l ON p.id_localidad = l.id_localidad
                 LEFT JOIN


### PR DESCRIPTION
The "unexpected error occurred during getting all people" error was caused by a typo in the `GetAllPersonas` method. The SQL query was referencing a non-existent table `tipos_doc` instead of the correct table `tipo_doc`.

This resulted in a `SqlException` which was caught and wrapped in a generic `BusinessLogicException`, masking the true cause of the error.

This commit corrects the typo in the table name. It also includes previous attempts to fix the issue which involved adding robust handling for `DBNull.Value` in the data mapping logic. While those changes were not the root cause of this specific error, they fix other potential bugs and make the code more resilient to inconsistent data.