### PR TITLE
Chore: Display full exception details for debugging

### DIFF
--- a/src/Presentation/AdminForm.cs
+++ b/src/Presentation/AdminForm.cs
@@ -257,7 +257,7 @@ namespace Presentation
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error al cargar personas: {ex.Message}", "Error");
+                MessageBox.Show($"Error al cargar personas: {ex.ToString()}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -493,7 +493,7 @@ namespace Presentation
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error al cargar personas: {ex.Message}", "Error");
+                MessageBox.Show($"Error al cargar personas: {ex.ToString()}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 


### PR DESCRIPTION
This commit modifies the error handling in `AdminForm.cs` to display the full exception details (`ex.ToString()`) in the message box when an error occurs while loading the list of people.

This change is intended to help diagnose a persistent and hard-to-find bug by providing more detailed information from the exception, including the stack trace and any inner exceptions.