### PR TITLE
 feat(services): Improve exception handling to provide detailed error …

### DIFF
--- a/src/BusinessLogic/Services/PersonaService.cs
+++ b/src/BusinessLogic/Services/PersonaService.cs
@@ -40,7 +40,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
             }
         }
 
@@ -57,7 +57,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
             }
         }
 

--- a/src/BusinessLogic/Services/UserManagementService.cs
+++ b/src/BusinessLogic/Services/UserManagementService.cs
@@ -57,7 +57,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
             }
         }
 
@@ -74,7 +74,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
             }
         }
         private async Task<T> ExecuteServiceOperationAsync<T>(Func<Task<T>> operation, string operationName)
@@ -90,7 +90,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
             }
         }
 
@@ -107,7 +107,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}.", ex);
+                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
             }
         }
 


### PR DESCRIPTION
…messages

The existing exception handling in the service layer was catching exceptions and re-throwing them as generic `BusinessLogicException`s. This practice obscured the original cause of the error, making it difficult to diagnose underlying issues such as database connection problems.

This commit modifies the `ExecuteServiceOperation` and `ExecuteServiceOperationAsync` helper methods in both `PersonaService` and `UserManagementService`. The exception handling has been updated to include the message from the original exception in the new `BusinessLogicException`.

This change will ensure that when an error occurs, the message displayed in the UI will contain specific details from the underlying exception (e.g., the `SqlException` message), making it much easier for users or developers to identify and resolve the root cause.