### PR TITLE
feat(diagnostics): Temporarily hardcode exception messages for diagno…

### DIFF
--- a/src/BusinessLogic/Services/PersonaService.cs
+++ b/src/BusinessLogic/Services/PersonaService.cs
@@ -40,7 +40,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
+                throw new BusinessLogicException("DIAGNOSTIC TEST: PERSONA SERVICE FAILED.", ex);
             }
         }
 
@@ -57,7 +57,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
+                throw new BusinessLogicException("DIAGNOSTIC TEST: PERSONA SERVICE FAILED.", ex);
             }
         }
 

--- a/src/BusinessLogic/Services/UserManagementService.cs
+++ b/src/BusinessLogic/Services/UserManagementService.cs
@@ -57,7 +57,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
+                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
             }
         }
 
@@ -74,7 +74,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
+                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
             }
         }
         private async Task<T> ExecuteServiceOperationAsync<T>(Func<Task<T>> operation, string operationName)
@@ -90,7 +90,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
+                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
             }
         }
 
@@ -107,7 +107,7 @@ namespace BusinessLogic.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException($"An unexpected error occurred during {operationName}: {ex.Message}", ex);
+                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
             }
         }
 


### PR DESCRIPTION
…stics

This is a temporary commit for diagnostic purposes.

You reported that my previous change to improve error message detail had no effect. To determine if your environment is running the updated code, this change temporarily replaces the dynamic exception messages in the service layer with hardcoded, unmistakable strings.

- `PersonaService` will now throw exceptions with the message "DIAGNOSTIC TEST: PERSONA SERVICE FAILED."
- `UserManagementService` will now throw exceptions with the message "DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED."

The goal is for you to run this version and report back which error message you see. This will confirm whether the code changes are being deployed and executed correctly. This commit should be reverted after the diagnostic test is complete.