### PR TITLE
refactor(services): Remove generic exception wrapping to expose detai…

### DIFF
--- a/src/BusinessLogic/Services/PersonaService.cs
+++ b/src/BusinessLogic/Services/PersonaService.cs
@@ -37,11 +37,6 @@ namespace BusinessLogic.Services
             {
                 throw;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException("DIAGNOSTIC TEST: PERSONA SERVICE FAILED.", ex);
-            }
         }
 
         private void ExecuteServiceOperation(Action operation, string operationName)
@@ -53,11 +48,6 @@ namespace BusinessLogic.Services
             catch (ValidationException)
             {
                 throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException("DIAGNOSTIC TEST: PERSONA SERVICE FAILED.", ex);
             }
         }
 

--- a/src/BusinessLogic/Services/UserManagementService.cs
+++ b/src/BusinessLogic/Services/UserManagementService.cs
@@ -54,11 +54,6 @@ namespace BusinessLogic.Services
             {
                 throw;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
-            }
         }
 
         private void ExecuteServiceOperation(Action operation, string operationName)
@@ -71,11 +66,6 @@ namespace BusinessLogic.Services
             {
                 throw;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
-            }
         }
         private async Task<T> ExecuteServiceOperationAsync<T>(Func<Task<T>> operation, string operationName)
         {
@@ -86,11 +76,6 @@ namespace BusinessLogic.Services
             catch (ValidationException)
             {
                 throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
             }
         }
 
@@ -103,11 +88,6 @@ namespace BusinessLogic.Services
             catch (ValidationException)
             {
                 throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during {OperationName}", operationName);
-                throw new BusinessLogicException("DIAGNOSTIC TEST: USER MANAGEMENT SERVICE FAILED.", ex);
             }
         }
 


### PR DESCRIPTION
…led errors

The previous implementation in the service layer's helper methods (`ExecuteServiceOperation`) caught all exceptions and re-wrapped them in a generic `BusinessLogicException`. This practice hid the original, more informative exceptions (e.g., `SqlException`, `InvalidCastException`) from the UI layer, making it difficult to diagnose the root cause of failures.

This commit refactors the exception handling in `PersonaService` and `UserManagementService`. The generic `catch (Exception ex)` blocks have been removed from the helper methods. Now, only `ValidationException` is explicitly handled at this layer. All other exceptions will propagate up the call stack to the presentation layer, which already has error handling in place to display the exception's message.

This change ensures that you will see the specific, detailed error message from the underlying exception, enabling you to effectively diagnose and resolve environment-specific issues like database connection problems.