### PR TITLE
Fix session management and password recovery flow

### DIFF
--- a/src/DataAccess/Repositories/SqlSecurityRepository.cs
+++ b/src/DataAccess/Repositories/SqlSecurityRepository.cs
@@ -96,17 +96,20 @@ namespace DataAccess.Repositories
             }
 
             var parameterNames = new List<string>();
+            for (int i = 0; i < ids.Count; i++)
+            {
+                parameterNames.Add($"@id{i}");
+            }
+
+            var sql = $"SELECT id_pregunta, pregunta FROM preguntas_seguridad WHERE id_pregunta IN ({string.Join(",", parameterNames)})";
+
             Action<SqlParameterCollection> addParametersAction = p =>
             {
                 for (int i = 0; i < ids.Count; i++)
                 {
-                    var paramName = $"@id{i}";
-                    parameterNames.Add(paramName);
-                    p.AddWithValue(paramName, ids[i]);
+                    p.AddWithValue(parameterNames[i], ids[i]);
                 }
             };
-
-            var sql = $"SELECT id_pregunta, pregunta FROM preguntas_seguridad WHERE id_pregunta IN ({string.Join(",", parameterNames)})";
 
             return ExecuteReader(sql, reader =>
             {


### PR DESCRIPTION
This commit addresses several issues related to session management and the password change/recovery process.

- **Application Closing Prematurely:** The application no longer exits when a user logs in or logs out. The login form is now hidden and shown again as appropriate.
- **Password Change Flow:** Fixed a SQL syntax error that occurred when retrieving a user's security questions. The password change form now closes correctly after a successful password change.
- **Password Recovery Flow:** The same SQL syntax error was affecting the password recovery process. This is now fixed.
- **Logout Functionality:** Closing the admin or user dashboard now correctly returns to the login screen instead of terminating the application.